### PR TITLE
Perf/optimize for dependent processing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['3.0', '3.1', '3.2', '3.3'] # Adjust as needed
+        ruby-version: ['3.2', '3.3'] # Adjust as needed
 
     services:
       postgres:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['3.2', '3.3'] # Adjust as needed
+        ruby-version: ['3.0', '3.1', '3.2', '3.3'] # Adjust as needed
 
     services:
       postgres:
         image: postgres:14
         env:
-          POSTGRES_DB: yantra_test
+          POSTGRES_DB: yantra_test # Ensure this matches your dummy app's database.yml
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: password
         options: >-
@@ -28,6 +28,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
         ports:
+          # Map container port 5432 to host port 5432
           - 5432:5432
 
     steps:
@@ -38,33 +39,44 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
-          bundler-cache: true # Runs bundle install
+          # Cache gems using bundler, runs `bundle install` from the root
+          bundler-cache: true
 
-      - name: Install system dependencies
+      - name: Install system dependencies (for pg gem)
         run: sudo apt-get update && sudo apt-get install -y libpq-dev
 
-      # Install gem dependencies (handled by bundler-cache: true)
+      # Gem dependencies installed by bundler-cache: true (runs in root)
+      # Note: If test/dummy has its own Gemfile, bundle install might need to run there too.
+      # Assuming test/dummy uses the root Gemfile for simplicity for now.
 
       - name: Set up test database
         env:
           RAILS_ENV: test
-          PGHOST: 127.0.0.1
-          PGPORT: 5432
+          # Point Rails to the service container
+          PGHOST: 127.0.0.1 # Use localhost/127.0.0.1 because of port mapping
+          PGPORT: 5432 # The host port mapped from the container
           PGUSER: postgres
           PGPASSWORD: password
-        # --- UPDATED: Use bin/rails instead of bundle exec ---
+        # --- UPDATED: Use bundle exec rails inside test/dummy ---
+        # Change directory to the dummy app first
+        working-directory: test/dummy
         run: |
-          bin/rails db:create db:schema:load RAILS_ENV=test
+          echo "Current directory: $(pwd)" # Should be test/dummy
+          # Use bundle exec to run the rails command from installed gems
+          bundle exec rails db:create
+          bundle exec rails db:schema:load
         # --- END UPDATE ---
-        working-directory: test/dummy # Keep running inside dummy app directory
 
       - name: Run tests
         env:
           RAILS_ENV: test
+          # Also ensure test environment uses the correct DB connection details
           PGHOST: 127.0.0.1
           PGPORT: 5432
           PGUSER: postgres
           PGPASSWORD: password
-        run: bundle exec rake test # Rake test likely still run from root
+        # Run tests from the project root (assuming rake tasks handle the dummy app context)
+        # If tests need to be run from test/dummy, add working-directory here too.
+        run: bundle exec rake test
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         # Specify the Ruby versions you want to support and test against
-        ruby-version: ['3.0', '3.1', '3.2', '3.3'] # Adjust as needed
+        ruby-version: ['3.2', '3.3'] # Adjust as needed
 
     # --- ADDED: PostgreSQL Service Container ---
     services:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,11 @@
 # .github/workflows/ci.yml
 
-name: Ruby Gem CI
+name: Ruby Gem CI (PostgreSQL)
 
 # Controls when the workflow will run
 on:
   push:
-    branches: [ main ] # Or your default branch (e.g., master)
+    branches: [ main ] # Or your default branch
   pull_request:
     branches: [ main ] # Or your default branch
 
@@ -14,11 +14,33 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
-    # --- MODIFIED: Test only one Ruby version for now ---
+    # Define a matrix strategy to test against multiple Ruby versions
     strategy:
       matrix:
-        # Specify only one Ruby version to isolate potential issues
-        ruby-version: ['3.1','3.2','3.3']
+        # Specify the Ruby versions you want to support and test against
+        ruby-version: ['3.0', '3.1', '3.2', '3.3'] # Adjust as needed
+
+    # --- ADDED: PostgreSQL Service Container ---
+    services:
+      # Label used to access the service container
+      postgres:
+        # Docker Hub image
+        image: postgres:14 # Choose desired PostgreSQL version
+        # Environment variables for the container (matching database.yml defaults/ENV)
+        env:
+          POSTGRES_DB: yantra_test
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: password # Use a simple password for CI
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          # Maps port 5432 on service container to 5432 on the runner host
+          - 5432:5432
+    # --- END SERVICE ---
 
     steps:
       # 1. Check out repository code
@@ -30,26 +52,39 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
-          # --- MODIFIED: Disable bundler-cache ---
-          bundler-cache: false
+          # Cache gems using Bundler for faster builds
+          bundler-cache: true # This runs bundle install
 
-      # 3. Install system dependencies (SQLite for testing)
+      # 3. Install system dependencies (PostgreSQL client libs)
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y libsqlite3-dev sqlite3
+        run: sudo apt-get update && sudo apt-get install -y libpq-dev
 
-      # --- ADDED: Explicit bundle install step ---
-      - name: Install dependencies
-        run: bundle install --jobs 4 --retry 3
+      # 4. Install gem dependencies (handled by bundler-cache: true)
 
       # 5. Set up the dummy app's test database
-      #    Assumes schema.rb is the source of truth. Use db:migrate if needed.
       - name: Set up test database
-        run: bundle exec rails db:schema:load RAILS_ENV=test
+        # Set environment variables needed by database.yml and Rails
+        # Note: PGHOST is set to 127.0.0.1 because the service port is mapped to the host runner
+        env:
+          RAILS_ENV: test
+          PGHOST: 127.0.0.1 # Or localhost
+          PGPORT: 5432 # Matches the service port mapping
+          PGUSER: postgres # Matches service env
+          PGPASSWORD: password # Matches service env
+        run: |
+          bundle exec rails db:create db:schema:load RAILS_ENV=test
         # Run this command within the dummy app directory
         working-directory: test/dummy
 
       # 6. Run tests
       - name: Run tests
+        # Pass environment variables to the test execution context
+        env:
+          RAILS_ENV: test
+          PGHOST: 127.0.0.1
+          PGPORT: 5432
+          PGUSER: postgres
+          PGPASSWORD: password
         run: bundle exec rake test
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,89 +2,69 @@
 
 name: Ruby Gem CI (PostgreSQL)
 
-# Controls when the workflow will run
 on:
   push:
-    branches: [ main ] # Or your default branch
+    branches: [ main ]
   pull_request:
-    branches: [ main ] # Or your default branch
+    branches: [ main ]
 
 jobs:
   test:
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
-
-    # Define a matrix strategy to test against multiple Ruby versions
     strategy:
       matrix:
-        # Specify the Ruby versions you want to support and test against
-        ruby-version: ['3.2', '3.3'] # Adjust as needed
+        ruby-version: ['3.0', '3.1', '3.2', '3.3'] # Adjust as needed
 
-    # --- ADDED: PostgreSQL Service Container ---
     services:
-      # Label used to access the service container
       postgres:
-        # Docker Hub image
-        image: postgres:14 # Choose desired PostgreSQL version
-        # Environment variables for the container (matching database.yml defaults/ENV)
+        image: postgres:14
         env:
           POSTGRES_DB: yantra_test
           POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: password # Use a simple password for CI
-        # Set health checks to wait until postgres has started
+          POSTGRES_PASSWORD: password
         options: >-
           --health-cmd pg_isready
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
         ports:
-          # Maps port 5432 on service container to 5432 on the runner host
           - 5432:5432
-    # --- END SERVICE ---
 
     steps:
-      # 1. Check out repository code
       - name: Checkout code
         uses: actions/checkout@v4
 
-      # 2. Set up Ruby environment
       - name: Set up Ruby ${{ matrix.ruby-version }}
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
-          # Cache gems using Bundler for faster builds
-          bundler-cache: true # This runs bundle install
+          bundler-cache: true # Runs bundle install
 
-      # 3. Install system dependencies (PostgreSQL client libs)
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y libpq-dev
 
-      # 4. Install gem dependencies (handled by bundler-cache: true)
+      # Install gem dependencies (handled by bundler-cache: true)
 
-      # 5. Set up the dummy app's test database
       - name: Set up test database
-        # Set environment variables needed by database.yml and Rails
-        # Note: PGHOST is set to 127.0.0.1 because the service port is mapped to the host runner
-        env:
-          RAILS_ENV: test
-          PGHOST: 127.0.0.1 # Or localhost
-          PGPORT: 5432 # Matches the service port mapping
-          PGUSER: postgres # Matches service env
-          PGPASSWORD: password # Matches service env
-        run: |
-          bundle exec rails db:create db:schema:load RAILS_ENV=test
-        # Run this command within the dummy app directory
-        working-directory: test/dummy
-
-      # 6. Run tests
-      - name: Run tests
-        # Pass environment variables to the test execution context
         env:
           RAILS_ENV: test
           PGHOST: 127.0.0.1
           PGPORT: 5432
           PGUSER: postgres
           PGPASSWORD: password
-        run: bundle exec rake test
+        # --- UPDATED: Use bin/rails instead of bundle exec ---
+        run: |
+          bin/rails db:create db:schema:load RAILS_ENV=test
+        # --- END UPDATE ---
+        working-directory: test/dummy # Keep running inside dummy app directory
+
+      - name: Run tests
+        env:
+          RAILS_ENV: test
+          PGHOST: 127.0.0.1
+          PGPORT: 5432
+          PGUSER: postgres
+          PGPASSWORD: password
+        run: bundle exec rake test # Rake test likely still run from root
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['3.2', '3.3'] # Adjust as needed
+        ruby-version: ['3.2', '3.3'] # Test only compatible versions
 
     services:
       postgres:
@@ -40,14 +40,11 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby-version }}
           # Cache gems using bundler, runs `bundle install` from the root
+          # This caches gems based on the ROOT Gemfile.lock
           bundler-cache: true
 
       - name: Install system dependencies (for pg gem)
         run: sudo apt-get update && sudo apt-get install -y libpq-dev
-
-      # Gem dependencies installed by bundler-cache: true (runs in root)
-      # Note: If test/dummy has its own Gemfile, bundle install might need to run there too.
-      # Assuming test/dummy uses the root Gemfile for simplicity for now.
 
       - name: Set up test database
         env:
@@ -57,15 +54,17 @@ jobs:
           PGPORT: 5432 # The host port mapped from the container
           PGUSER: postgres
           PGPASSWORD: password
-        # --- UPDATED: Use bundle exec rails inside test/dummy ---
         # Change directory to the dummy app first
         working-directory: test/dummy
         run: |
           echo "Current directory: $(pwd)" # Should be test/dummy
-          # Use bundle exec to run the rails command from installed gems
+          # --- UPDATED: Run bundle install inside test/dummy ---
+          # Install gems specific to the dummy app's Gemfile
+          bundle install
+          # --- END UPDATE ---
+          # Now, use bundle exec to run the rails command from installed gems
           bundle exec rails db:create
           bundle exec rails db:schema:load
-        # --- END UPDATE ---
 
       - name: Run tests
         env:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,6 +132,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.18.7-x86_64-linux-gnu)
       racc (~> 1.4)
+    pg (1.5.9)
     pp (0.6.2)
       prettyprint
     prettyprint (0.2.0)
@@ -210,6 +211,7 @@ DEPENDENCIES
   minitest (~> 5.0)
   minitest-focus
   mocha
+  pg
   pry
   rails (>= 6.0)
   rake (~> 13.0)

--- a/lib/generators/yantra/install/templates/create_yantra_steps.rb
+++ b/lib/generators/yantra/install/templates/create_yantra_steps.rb
@@ -13,13 +13,13 @@ class CreateYantraSteps < ActiveRecord::Migration[<%= ActiveRecord::Migration.cu
 
       # Basic step information
       t.string :klass, null: false        # Stores the class name of the user-defined step.
-      t.json :arguments                   # Stores the arguments passed to the step's perform method (use :text if :json type not supported).
+      t.jsonb :arguments                   # Stores the arguments passed to the step's perform method (use :text if :json type not supported).
       t.string :state, null: false, index: true # Stores the current state of the step. Indexed.
       t.string :queue                     # Stores the name of the background queue this step should run on.
       t.integer :retries, default: 0, null: false # Counter for how many times this step has been retried.
       t.integer :max_attempts, default: 3, null: false # Stores the maximum number of attempts allowed for this step instance.
-      t.json :output                    # Stores the return value of the step's perform method upon success (use :text if :json type not supported).
-      t.json :error                     # Stores information about the last error if the step failed (use :text if :json type not supported).
+      t.jsonb :output                    # Stores the return value of the step's perform method upon success (use :text if :json type not supported).
+      t.jsonb :error                     # Stores information about the last error if the step failed (use :text if :json type not supported).
 
       # Timestamps (using t.timestamp)
       t.timestamp :created_at, null: false # Timestamp for when the step record was created.

--- a/lib/generators/yantra/install/templates/create_yantra_workflows.rb
+++ b/lib/generators/yantra/install/templates/create_yantra_workflows.rb
@@ -8,9 +8,9 @@ class CreateYantraWorkflows < ActiveRecord::Migration[<%= ActiveRecord::Migratio
 
       # Basic workflow information
       t.string :klass, null: false       # Stores the class name of the user-defined workflow.
-      t.json :arguments                  # Stores the initial arguments passed to the workflow (use :text if :json type not supported).
+      t.jsonb :arguments                  # Stores the initial arguments passed to the workflow (use :text if :json type not supported).
       t.string :state, null: false       # Stores the current state (e.g., pending, running, succeeded, failed).
-      t.json :globals                    # Optional field for storing global data (use :text if :json type not supported).
+      t.jsonb :globals                    # Optional field for storing global data (use :text if :json type not supported).
       t.boolean :has_failures, null: false, default: false # Flag indicating if any step within the workflow has failed permanently.
 
       # Timestamps (using t.timestamp for cross-db compatibility)

--- a/lib/yantra/persistence/repository_interface.rb
+++ b/lib/yantra/persistence/repository_interface.rb
@@ -2,43 +2,43 @@
 
 module Yantra
   module Persistence
+    # Defines the contract for persistence adapters.
+    # Adapters must implement all these methods.
     module RepositoryInterface
-      # --- Workflow Methods ---
+      # Implement methods for Workflow CRUD and state management
       def find_workflow(workflow_id); raise NotImplementedError; end
       def persist_workflow(workflow_instance); raise NotImplementedError; end
       def update_workflow_attributes(workflow_id, attributes_hash, expected_old_state: nil); raise NotImplementedError; end
       def set_workflow_has_failures_flag(workflow_id); raise NotImplementedError; end
       def workflow_has_failures?(workflow_id); raise NotImplementedError; end
 
-      # --- Step Methods ---
+      # Implement methods for Step CRUD and state management
       def find_step(step_id); raise NotImplementedError; end
       def persist_step(step_instance); raise NotImplementedError; end
       def persist_steps_bulk(step_instances_array); raise NotImplementedError; end
       def update_step_attributes(step_id, attributes_hash, expected_old_state: nil); raise NotImplementedError; end
       def running_step_count(workflow_id); raise NotImplementedError; end
-      def enqueued_step_count(workflow_id); raise NotImplementedError; end
+      def enqueued_step_count(workflow_id); raise NotImplementedError; end # Added for potential use
       def get_workflow_steps(workflow_id, status: nil); raise NotImplementedError; end
       def increment_step_retries(step_id); raise NotImplementedError; end
       def record_step_output(step_id, output); raise NotImplementedError; end
       def record_step_error(step_id, error); raise NotImplementedError; end
+      def fetch_step_states(step_ids); raise NotImplementedError; end
 
-      # --- Dependency Methods ---
+      # Implement methods for Dependencies
       def add_step_dependency(step_id, dependency_step_id); raise NotImplementedError; end
       def add_step_dependencies_bulk(dependency_links_array); raise NotImplementedError; end
-      def get_step_dependencies(step_id); raise NotImplementedError; end # Returns IDs of steps this step depends on (parents)
-      def get_step_dependents(step_id); raise NotImplementedError; end # Returns IDs of steps that depend on this step (children)
+      def get_step_dependencies(step_id); raise NotImplementedError; end
+      def get_step_dependents(step_id); raise NotImplementedError; end
       def find_ready_steps(workflow_id); raise NotImplementedError; end
 
-      # --- Bulk Operations ---
+      # Implement methods for Bulk Operations / Cleanup
       def cancel_steps_bulk(step_ids); raise NotImplementedError; end
-
-      # --- Listing/Cleanup Methods ---
       def list_workflows(status: nil, limit: 50, offset: 0); raise NotImplementedError; end
       def delete_workflow(workflow_id); raise NotImplementedError; end
       def delete_expired_workflows(cutoff_timestamp); raise NotImplementedError; end
-
-      # --- Pipelining Methods --- NEW! ---
       def fetch_step_outputs(step_ids); raise NotImplementedError; end
+      def get_step_dependencies_multi(step_ids); raise NotImplementedError; end
     end
   end
 end

--- a/lib/yantra/worker/active_job/step_job.rb
+++ b/lib/yantra/worker/active_job/step_job.rb
@@ -43,132 +43,79 @@ module Yantra
         attr_accessor :executions unless defined?(executions)
 
         def perform(yantra_step_id, yantra_workflow_id, yantra_step_klass_name)
-          self.executions ||= 1
+          self.executions = self.executions || 1
 
-
-          # --- Get dependencies (Repo, Notifier) ---
-          # Note: Still using global accessors here. Injecting these into StepJob
-          # itself would be a larger refactor.
+          puts "INFO: [AJ::StepJob] Attempt ##{self.executions} for Yantra step: #{yantra_step_id} WF: #{yantra_workflow_id} Klass: #{yantra_step_klass_name}"
           repo = Yantra.repository
-          notifier = Yantra.notifier # Get notifier instance
-          unless repo
-             raise Yantra::Errors::ConfigurationError, "Yantra repository not configured."
-          end
-          # Notifier can be nil if configured as :null, handle that downstream
-          # --- End Get dependencies ---
-
-          orchestrator = Yantra::Core::Orchestrator.new(repository: repo, notifier: notifier) # Pass notifier to Orchestrator too
+          notifier = Yantra.notifier
+          unless repo; raise Yantra::Errors::ConfigurationError, "Yantra repository not configured."; end
+          orchestrator = Yantra::Core::Orchestrator.new(repository: repo, notifier: notifier)
 
           step_record = nil
           user_step_klass = nil
 
-          # --- 1. Notify Orchestrator: Starting ---
-          unless orchestrator.step_starting(yantra_step_id)
+          unless orchestrator.step_starting(yantra_step_id); puts "WARN: [AJ::StepJob] Orchestrator#step_starting indicated job #{yantra_step_id} should not proceed. Aborting."; return; end
 
-             return
-          end
-
-          # --- 2. Execute User Code ---
           begin
             step_record = repo.find_step(yantra_step_id)
-            unless step_record
-               raise Yantra::Errors::StepNotFound, "Job record #{yantra_step_id} not found after starting."
-            end
-            yantra_step_klass_name = step_record.klass # Use klass from record
+            unless step_record; raise Yantra::Errors::StepNotFound, "Job record #{yantra_step_id} not found after starting."; end
+            yantra_step_klass_name = step_record.klass
 
-            begin
-              user_step_klass = Object.const_get(yantra_step_klass_name)
-            rescue NameError => e
-              raise Yantra::Errors::StepDefinitionError, "Class #{yantra_step_klass_name} could not be loaded: #{e.message}"
-            end
+            begin; user_step_klass = Object.const_get(yantra_step_klass_name); rescue NameError => e; raise Yantra::Errors::StepDefinitionError, "Class #{yantra_step_klass_name} could not be loaded: #{e.message}"; end
+            unless user_step_klass && user_step_klass < Yantra::Step; raise Yantra::Errors::StepDefinitionError, "Class #{yantra_step_klass_name} is not a Yantra::Step subclass."; end
 
-            unless user_step_klass && user_step_klass < Yantra::Step
-               raise Yantra::Errors::StepDefinitionError, "Class #{yantra_step_klass_name} is not a Yantra::Step subclass."
-            end
-
-            # --- Argument Handling (remains the same) ---
-            raw_arguments = step_record.arguments
-            arguments_hash = {}
-            if raw_arguments.is_a?(Hash)
-              arguments_hash = raw_arguments
-            elsif raw_arguments.is_a?(String) && !raw_arguments.empty?
-              begin; arguments_hash = JSON.parse(raw_arguments); arguments_hash = {} unless arguments_hash.is_a?(Hash); rescue JSON::ParserError; arguments_hash = {}; end
-            elsif raw_arguments.nil?; arguments_hash = {}
-            else; arguments_hash = {}; end
-            final_arguments_hash = if arguments_hash.respond_to?(:deep_symbolize_keys); begin; arguments_hash.deep_symbolize_keys; rescue => e; puts "WARN: [AJ::StepJob] deep_symbolize_keys failed: #{e.message}. Falling back."; arguments_hash.transform_keys(&:to_sym) rescue {}; end; else; arguments_hash.transform_keys(&:to_sym) rescue {}; end
-            # --- END Argument Handling ---
+            # Argument Handling
+            raw_arguments = step_record.arguments; arguments_hash = {}; if raw_arguments.is_a?(Hash); arguments_hash = raw_arguments; elsif raw_arguments.is_a?(String) && !raw_arguments.empty?; begin; arguments_hash = JSON.parse(raw_arguments); arguments_hash = {} unless arguments_hash.is_a?(Hash); rescue JSON::ParserError; arguments_hash = {}; end; elsif raw_arguments.nil?; arguments_hash = {}; else; arguments_hash = {}; end; final_arguments_hash = if arguments_hash.respond_to?(:deep_symbolize_keys); begin; arguments_hash.deep_symbolize_keys; rescue => e; puts "WARN: [AJ::StepJob] deep_symbolize_keys failed: #{e.message}. Falling back."; arguments_hash.transform_keys(&:to_sym) rescue {}; end; else; arguments_hash.transform_keys(&:to_sym) rescue {}; end
 
             parent_ids = repo.get_step_dependencies(yantra_step_id)
-
-            user_step_instance = user_step_klass.new(
-              step_id: step_record.id,
-              workflow_id: step_record.workflow_id,
-              klass: user_step_klass,
-              arguments: final_arguments_hash,
-              parent_ids: parent_ids,
-              queue_name: step_record.queue,
-              repository: repo # Inject repository for parent_outputs
-            )
-
+            user_step_instance = user_step_klass.new(step_id: step_record.id, workflow_id: step_record.workflow_id, klass: user_step_klass, arguments: final_arguments_hash, parent_ids: parent_ids, queue_name: step_record.queue, repository: repo)
             final_arguments_hash_for_perform = final_arguments_hash.transform_keys(&:to_sym) rescue {}
-
+            puts "DEBUG: [AJ::StepJob] Arguments being passed to perform: #{final_arguments_hash_for_perform.inspect}"
 
             result = user_step_instance.perform(**final_arguments_hash_for_perform)
 
-            # --- 3a. Notify Orchestrator: Success ---
             orchestrator.step_succeeded(yantra_step_id, result)
 
           rescue StandardError => e
-            # --- 3b. Handle Failure via RetryHandler ---
-
-            unless step_record
-
-              raise e # Re-raise original error if step_record is missing
-            end
-            # Ensure user_step_klass is defined, fallback to base Step class if loading failed earlier
+            # --- DEBUGGING BLOCK ---
+            puts "\nDEBUG: [AJ::StepJob] Rescued error in perform for step #{yantra_step_id}: #{e.class} - #{e.message}"
+            unless step_record; puts "FATAL: [AJ::StepJob] Cannot handle error - step_record not loaded."; raise e; end
             user_klass_for_handler = user_step_klass || Yantra::Step
-
-            # Get the configured or default RetryHandler class
             retry_handler_class = Yantra.configuration.try(:retry_handler_class) || Yantra::Worker::RetryHandler
+            puts "DEBUG: [AJ::StepJob] Using RetryHandler: #{retry_handler_class}"
+            puts "DEBUG: [AJ::StepJob] Current executions: #{self.executions}"
+            # --- END DEBUGGING BLOCK ---
 
-            # --- UPDATED: Instantiate RetryHandler with injected notifier ---
-            handler = retry_handler_class.new(
-              repository: repo,
-              step_record: step_record,
-              error: e,
-              executions: self.executions,
-              user_step_klass: user_klass_for_handler,
-              notifier: notifier # Pass the notifier instance
-            )
-            # --- END UPDATE ---
+            handler = retry_handler_class.new(repository: repo, step_record: step_record, error: e, executions: self.executions, user_step_klass: user_klass_for_handler, notifier: notifier)
 
             begin
               outcome = handler.handle_error!
-              # If handler returns :failed, it means max attempts reached and handled
+              # --- DEBUGGING BLOCK ---
+              puts "DEBUG: [AJ::StepJob] RetryHandler outcome: #{outcome.inspect}"
+              # --- END DEBUGGING BLOCK ---
+
               if outcome == :failed
-
-                # Fetch final state to ensure it's marked failed before calling step_finished
-                final_record = repo.find_step(yantra_step_id)
-                if final_record&.state&.to_sym == Yantra::Core::StateMachine::FAILED
-                   orchestrator.step_finished(yantra_step_id)
-                else
-                   # Log warning if state isn't as expected after handler indicated permanent failure
-
-                end
+                 puts "DEBUG: [AJ::StepJob] Outcome is :failed. Notifying orchestrator job finished." # DEBUG
+                 final_record = repo.find_step(yantra_step_id)
+                 if final_record&.state&.to_sym == Yantra::Core::StateMachine::FAILED
+                    orchestrator.step_finished(yantra_step_id)
+                 else
+                    puts "WARN: [AJ::StepJob] RetryHandler indicated permanent failure, but step state is not 'failed'. State: #{final_record&.state}"
+                 end
+                 # Do NOT re-raise error
+              else
+                 puts "DEBUG: [AJ::StepJob] Outcome is NOT :failed. Re-raising error for background job system." # DEBUG
+                 # Handler must have re-raised the error for retry
+                 raise e # Re-raise the original error 'e'
               end
-              # If handler didn't return :failed, it must have re-raised the error for retry
             rescue => retry_error
-              # Ensure we propagate the *original* error if handler raises something different
-              unless retry_error.equal?(e)
-
-                 retry_error = e
-              end
-
-              raise retry_error # Re-raise for ActiveJob backend retry mechanism
-            end # Inner begin/rescue for handler call
-
+              puts "DEBUG: [AJ::StepJob] Rescued error from handler block: #{retry_error.class} - #{retry_error.message}" # DEBUG
+              unless retry_error.equal?(e); puts "WARN: [AJ::StepJob] RetryHandler raised a different error than expected. Propagating original error."; retry_error = e; end
+              raise retry_error
+            end
           end # Outer begin/rescue for perform
         end # end perform
+
       end # class StepJob
     end
   end

--- a/test/core/orchestrator_test.rb
+++ b/test/core/orchestrator_test.rb
@@ -22,6 +22,7 @@ MockStep = Struct.new(:id, :workflow_id, :klass, :state, :queue, :output, :error
     super(id, workflow_id, klass, state.to_s, queue, output, error, retries, created_at, enqueued_at, started_at, finished_at, dependencies || [])
   end
 end
+
 MockWorkflow = Struct.new(:id, :state, :klass, :started_at, :finished_at, :has_failures) do
   def initialize(id: nil, state: 'pending', klass: nil, started_at: nil, finished_at: nil, has_failures: false)
     # Ensure state is stored as a string
@@ -245,114 +246,114 @@ module Yantra
       # --- UPDATED: Reworked expectations for fetch_step_states ---
       # test/core/orchestrator_test.rb (Specific Test - Fixed Expectations for Optimized Path)
       def test_step_finished_success_enqueues_ready_dependent
-  mocks = setup_mocha_mocks_and_orchestrator
-  repo = mocks[:repo]; notifier = mocks[:notifier]; worker = mocks[:worker]; orchestrator = mocks[:orchestrator]
-  # Setup: Step A succeeded, Step B depends on A and is pending
-  step_a_succeeded = MockStep.new(id: @step_a_id, workflow_id: @workflow_id, state: 'succeeded')
-  step_b_pending = MockStep.new(id: @step_b_id, workflow_id: @workflow_id, klass: "StepB", state: 'pending', queue: 'q_b')
-  step_b_enqueued = MockStep.new(id: @step_b_id, workflow_id: @workflow_id, klass: "StepB", state: 'enqueued', queue: 'q_b', enqueued_at: @frozen_time)
+        mocks = setup_mocha_mocks_and_orchestrator
+        repo = mocks[:repo]; notifier = mocks[:notifier]; worker = mocks[:worker]; orchestrator = mocks[:orchestrator]
+        # Setup: Step A succeeded, Step B depends on A and is pending
+        step_a_succeeded = MockStep.new(id: @step_a_id, workflow_id: @workflow_id, state: 'succeeded')
+        step_b_pending = MockStep.new(id: @step_b_id, workflow_id: @workflow_id, klass: "StepB", state: 'pending', queue: 'q_b')
+        step_b_enqueued = MockStep.new(id: @step_b_id, workflow_id: @workflow_id, klass: "StepB", state: 'enqueued', queue: 'q_b', enqueued_at: @frozen_time)
 
-  Time.stub :current, @frozen_time do
-    sequence = Mocha::Sequence.new('step_finished_success_enqueues_fixed') # Use a unique sequence name
+        Time.stub :current, @frozen_time do
+          sequence = Mocha::Sequence.new('step_finished_success_enqueues_fixed') # Use a unique sequence name
 
-    # Expectations for step_finished(A)
-    repo.expects(:find_step).with(@step_a_id).returns(step_a_succeeded).in_sequence(sequence)
-    repo.expects(:get_step_dependents).with(@step_a_id).returns([@step_b_id]).in_sequence(sequence) # B depends on A
+          # Expectations for step_finished(A)
+          repo.expects(:find_step).with(@step_a_id).returns(step_a_succeeded).in_sequence(sequence)
+          repo.expects(:get_step_dependents).with(@step_a_id).returns([@step_b_id]).in_sequence(sequence) # B depends on A
 
-    # --- Expectations for process_dependents (Optimized Success Path) ---
-    # 1. Bulk fetch dependencies for dependents [B]
-    repo.expects(:get_step_dependencies_multi).with([@step_b_id]).returns({ @step_b_id => [@step_a_id] }).in_sequence(sequence) # <<< USE MULTI
-    # 2. Bulk fetch states for parents [A] AND dependent [B]
-    ids_to_fetch = [@step_b_id, @step_a_id].uniq
-    repo.expects(:fetch_step_states)
-        .with() { |actual_ids| actual_ids.sort == ids_to_fetch.sort } # Match array content ignoring order
-        .returns({ @step_a_id => 'succeeded', @step_b_id => 'pending' }) # <<< CORRECT RETURN HASH
-        .in_sequence(sequence)
-    # 3. is_ready_to_start?(B) uses the hash, no find_step(B) call expected here
-    # --- End process_dependents expectations ---
+          # --- Expectations for process_dependents (Optimized Success Path) ---
+          # 1. Bulk fetch dependencies for dependents [B]
+          repo.expects(:get_step_dependencies_multi).with([@step_b_id]).returns({ @step_b_id => [@step_a_id] }).in_sequence(sequence) # <<< USE MULTI
+          # 2. Bulk fetch states for parents [A] AND dependent [B]
+          ids_to_fetch = [@step_b_id, @step_a_id].uniq
+          repo.expects(:fetch_step_states)
+            .with() { |actual_ids| actual_ids.sort == ids_to_fetch.sort } # Match array content ignoring order
+            .returns({ @step_a_id => 'succeeded', @step_b_id => 'pending' }) # <<< CORRECT RETURN HASH
+            .in_sequence(sequence)
+          # 3. is_ready_to_start?(B) uses the hash, no find_step(B) call expected here
+          # --- End process_dependents expectations ---
 
-    # --- Expectations for enqueue_step(B) because it's ready ---
-    # 4. find_step(B) at start of enqueue_step
-    repo.expects(:find_step).with(@step_b_id).returns(step_b_pending).in_sequence(sequence)
-    # 5. Update B to enqueued (Use keyword arg)
-    repo.expects(:update_step_attributes)
-        .with(@step_b_id, has_entries(state: StateMachine::ENQUEUED.to_s), expected_old_state: StateMachine::PENDING)
-        .returns(true).in_sequence(sequence)
-    # 6. Find B again (for payload/enqueue)
-    repo.expects(:find_step).with(@step_b_id).returns(step_b_enqueued).in_sequence(sequence)
-    # 7. Publish enqueued event for B
-    notifier.expects(:publish).with('yantra.step.enqueued', has_entries(step_id: @step_b_id)).in_sequence(sequence)
-    # 8. Enqueue B job
-    worker.expects(:enqueue).with(@step_b_id, @workflow_id, "StepB", "q_b").in_sequence(sequence)
-    # --- End enqueue_step expectations ---
+          # --- Expectations for enqueue_step(B) because it's ready ---
+          # 4. find_step(B) at start of enqueue_step
+          repo.expects(:find_step).with(@step_b_id).returns(step_b_pending).in_sequence(sequence)
+          # 5. Update B to enqueued (Use keyword arg)
+          repo.expects(:update_step_attributes)
+            .with(@step_b_id, has_entries(state: StateMachine::ENQUEUED.to_s), expected_old_state: StateMachine::PENDING)
+            .returns(true).in_sequence(sequence)
+          # 6. Find B again (for payload/enqueue)
+          repo.expects(:find_step).with(@step_b_id).returns(step_b_enqueued).in_sequence(sequence)
+          # 7. Publish enqueued event for B
+          notifier.expects(:publish).with('yantra.step.enqueued', has_entries(step_id: @step_b_id)).in_sequence(sequence)
+          # 8. Enqueue B job
+          worker.expects(:enqueue).with(@step_b_id, @workflow_id, "StepB", "q_b").in_sequence(sequence)
+          # --- End enqueue_step expectations ---
 
-    # --- Expectations for check_workflow_completion ---
-    # 9. Check counts
-    repo.expects(:running_step_count).with(@workflow_id).returns(0).in_sequence(sequence)
-    repo.expects(:enqueued_step_count).with(@workflow_id).returns(1).in_sequence(sequence) # B is now enqueued
-    # Note: check_workflow_completion exits here as enqueued_count > 0
-    # --- End check_workflow_completion expectations ---
+          # --- Expectations for check_workflow_completion ---
+          # 9. Check counts
+          repo.expects(:running_step_count).with(@workflow_id).returns(0).in_sequence(sequence)
+          repo.expects(:enqueued_step_count).with(@workflow_id).returns(1).in_sequence(sequence) # B is now enqueued
+          # Note: check_workflow_completion exits here as enqueued_count > 0
+          # --- End check_workflow_completion expectations ---
 
-    # Act
-    orchestrator.step_finished(@step_a_id)
-    # Assertions handled by mock verification
-  end
-end
+          # Act
+          orchestrator.step_finished(@step_a_id)
+          # Assertions handled by mock verification
+        end
+      end
 
 
       # --- UPDATED: Reworked expectations ---
       # test/core/orchestrator_test.rb (Specific Test - Fixed Expectations)
 
       def test_step_finished_success_does_not_enqueue_if_deps_not_met
-  mocks = setup_mocha_mocks_and_orchestrator
-  repo = mocks[:repo]; notifier = mocks[:notifier]; orchestrator = mocks[:orchestrator]
-  # Setup: A succeeded, C depends on A & B, B is still pending
-  step_a_succeeded = MockStep.new(id: @step_a_id, workflow_id: @workflow_id, state: 'succeeded', klass: "StepA")
-  step_b_pending = MockStep.new(id: @step_b_id, workflow_id: @workflow_id, state: 'pending')
-  step_c_pending = MockStep.new(id: @step_c_id, workflow_id: @workflow_id, state: 'pending', klass: "StepC")
-  workflow_running = MockWorkflow.new(id: @workflow_id, klass: "MyWorkflow", state: 'running')
-  workflow_succeeded = MockWorkflow.new(id: @workflow_id, klass: "MyWorkflow", state: 'succeeded', finished_at: @frozen_time)
+        mocks = setup_mocha_mocks_and_orchestrator
+        repo = mocks[:repo]; notifier = mocks[:notifier]; orchestrator = mocks[:orchestrator]
+        # Setup: A succeeded, C depends on A & B, B is still pending
+        step_a_succeeded = MockStep.new(id: @step_a_id, workflow_id: @workflow_id, state: 'succeeded', klass: "StepA")
+        step_b_pending = MockStep.new(id: @step_b_id, workflow_id: @workflow_id, state: 'pending')
+        step_c_pending = MockStep.new(id: @step_c_id, workflow_id: @workflow_id, state: 'pending', klass: "StepC")
+        workflow_running = MockWorkflow.new(id: @workflow_id, klass: "MyWorkflow", state: 'running')
+        workflow_succeeded = MockWorkflow.new(id: @workflow_id, klass: "MyWorkflow", state: 'succeeded', finished_at: @frozen_time)
 
-  Time.stub :current, @frozen_time do
-    sequence = Mocha::Sequence.new('step_finished_deps_not_met_completes_fixed')
+        Time.stub :current, @frozen_time do
+          sequence = Mocha::Sequence.new('step_finished_deps_not_met_completes_fixed')
 
-    # Expectations for step_finished(A)
-    repo.expects(:find_step).with(@step_a_id).returns(step_a_succeeded).in_sequence(sequence)
-    repo.expects(:get_step_dependents).with(@step_a_id).returns([@step_c_id]).in_sequence(sequence) # C depends on A
+          # Expectations for step_finished(A)
+          repo.expects(:find_step).with(@step_a_id).returns(step_a_succeeded).in_sequence(sequence)
+          repo.expects(:get_step_dependents).with(@step_a_id).returns([@step_c_id]).in_sequence(sequence) # C depends on A
 
-    # --- Expectations for process_dependents (Optimized Success Path) ---
-    # 1. Bulk fetch dependencies for dependents [C]
-    repo.expects(:get_step_dependencies_multi).with([@step_c_id]).returns({ @step_c_id => [@step_a_id, @step_b_id] }).in_sequence(sequence) # <<< CORRECTED EXPECTATION
-    # 2. Bulk fetch states for parents [A, B] AND dependent [C]
-    ids_to_fetch = [@step_c_id, @step_a_id, @step_b_id].uniq
-    repo.expects(:fetch_step_states)
-        .with() { |actual_ids| actual_ids.sort == ids_to_fetch.sort } # Match array content ignoring order
-        .returns({ @step_c_id => 'pending', @step_a_id => 'succeeded', @step_b_id => 'pending' }) # <<< CORRECTED ARGS/RETURN
-        .in_sequence(sequence)
-    # 3. is_ready_to_start?(C) uses the hash, no find_step(C) call expected here
-    # repo.expects(:find_step).with(@step_c_id).returns(step_c_pending).in_sequence(sequence) # <<< REMOVED EXPECTATION
-    # --- End process_dependents expectations ---
+          # --- Expectations for process_dependents (Optimized Success Path) ---
+          # 1. Bulk fetch dependencies for dependents [C]
+          repo.expects(:get_step_dependencies_multi).with([@step_c_id]).returns({ @step_c_id => [@step_a_id, @step_b_id] }).in_sequence(sequence) # <<< CORRECTED EXPECTATION
+          # 2. Bulk fetch states for parents [A, B] AND dependent [C]
+          ids_to_fetch = [@step_c_id, @step_a_id, @step_b_id].uniq
+          repo.expects(:fetch_step_states)
+            .with() { |actual_ids| actual_ids.sort == ids_to_fetch.sort } # Match array content ignoring order
+            .returns({ @step_c_id => 'pending', @step_a_id => 'succeeded', @step_b_id => 'pending' }) # <<< CORRECTED ARGS/RETURN
+            .in_sequence(sequence)
+          # 3. is_ready_to_start?(C) uses the hash, no find_step(C) call expected here
+          # repo.expects(:find_step).with(@step_c_id).returns(step_c_pending).in_sequence(sequence) # <<< REMOVED EXPECTATION
+          # --- End process_dependents expectations ---
 
-    # Note: enqueue_step(C) is NOT called because B is pending
+          # Note: enqueue_step(C) is NOT called because B is pending
 
-    # --- Expectations for check_workflow_completion ---
-    repo.expects(:running_step_count).with(@workflow_id).returns(0).in_sequence(sequence)
-    repo.expects(:enqueued_step_count).with(@workflow_id).returns(0).in_sequence(sequence) # Nothing got enqueued
-    repo.expects(:find_workflow).with(@workflow_id).returns(workflow_running).in_sequence(sequence) # Check if terminal
-    repo.expects(:workflow_has_failures?).with(@workflow_id).returns(false).in_sequence(sequence) # No failures
-    # Update workflow to succeeded (FIX: Use keyword arg)
-    repo.expects(:update_workflow_attributes)
-        .with(@workflow_id, { state: StateMachine::SUCCEEDED.to_s, finished_at: @frozen_time }, expected_old_state: StateMachine::RUNNING) # <<< CORRECTED EXPECTATION
-        .returns(true).in_sequence(sequence)
-    repo.expects(:find_workflow).with(@workflow_id).returns(workflow_succeeded).in_sequence(sequence) # For event payload
-    notifier.expects(:publish).with('yantra.workflow.succeeded', has_entries(workflow_id: @workflow_id, state: :succeeded)).in_sequence(sequence)
-    # --- End check_workflow_completion expectations ---
+          # --- Expectations for check_workflow_completion ---
+          repo.expects(:running_step_count).with(@workflow_id).returns(0).in_sequence(sequence)
+          repo.expects(:enqueued_step_count).with(@workflow_id).returns(0).in_sequence(sequence) # Nothing got enqueued
+          repo.expects(:find_workflow).with(@workflow_id).returns(workflow_running).in_sequence(sequence) # Check if terminal
+          repo.expects(:workflow_has_failures?).with(@workflow_id).returns(false).in_sequence(sequence) # No failures
+          # Update workflow to succeeded (FIX: Use keyword arg)
+          repo.expects(:update_workflow_attributes)
+            .with(@workflow_id, { state: StateMachine::SUCCEEDED.to_s, finished_at: @frozen_time }, expected_old_state: StateMachine::RUNNING) # <<< CORRECTED EXPECTATION
+            .returns(true).in_sequence(sequence)
+          repo.expects(:find_workflow).with(@workflow_id).returns(workflow_succeeded).in_sequence(sequence) # For event payload
+          notifier.expects(:publish).with('yantra.workflow.succeeded', has_entries(workflow_id: @workflow_id, state: :succeeded)).in_sequence(sequence)
+          # --- End check_workflow_completion expectations ---
 
-    # Act
-    orchestrator.step_finished(@step_a_id)
-    # Assertions handled by mock verification
-  end
-end
+          # Act
+          orchestrator.step_finished(@step_a_id)
+          # Assertions handled by mock verification
+        end
+      end
 
 
 
@@ -396,73 +397,73 @@ end
       # test/core/orchestrator_test.rb (Specific Test - Fixed)
 
       def test_step_finished_failure_cancels_dependents_recursively
-  mocks = setup_mocha_mocks_and_orchestrator
-  repo = mocks[:repo]; notifier = mocks[:notifier]; orchestrator = mocks[:orchestrator]
-  # Setup: A failed, B depends on A (pending), C depends on B (pending)
-  step_a_failed = MockStep.new(id: @step_a_id, workflow_id: @workflow_id, state: 'failed')
-  step_b_pending = MockStep.new(id: @step_b_id, workflow_id: @workflow_id, klass: "StepB", state: 'pending')
-  step_c_pending = MockStep.new(id: @step_c_id, workflow_id: @workflow_id, klass: "StepC", state: 'pending')
-  step_b_cancelled = MockStep.new(id: @step_b_id, workflow_id: @workflow_id, klass: "StepB", state: 'cancelled')
-  step_c_cancelled = MockStep.new(id: @step_c_id, workflow_id: @workflow_id, klass: "StepC", state: 'cancelled')
-  workflow_running = MockWorkflow.new(id: @workflow_id, klass: "MyWorkflow", state: 'running')
-  workflow_failed = MockWorkflow.new(id: @workflow_id, klass: "MyWorkflow", state: 'failed', finished_at: @frozen_time)
+        mocks = setup_mocha_mocks_and_orchestrator
+        repo = mocks[:repo]; notifier = mocks[:notifier]; orchestrator = mocks[:orchestrator]
+        # Setup: A failed, B depends on A (pending), C depends on B (pending)
+        step_a_failed = MockStep.new(id: @step_a_id, workflow_id: @workflow_id, state: 'failed')
+        step_b_pending = MockStep.new(id: @step_b_id, workflow_id: @workflow_id, klass: "StepB", state: 'pending')
+        step_c_pending = MockStep.new(id: @step_c_id, workflow_id: @workflow_id, klass: "StepC", state: 'pending')
+        step_b_cancelled = MockStep.new(id: @step_b_id, workflow_id: @workflow_id, klass: "StepB", state: 'cancelled')
+        step_c_cancelled = MockStep.new(id: @step_c_id, workflow_id: @workflow_id, klass: "StepC", state: 'cancelled')
+        workflow_running = MockWorkflow.new(id: @workflow_id, klass: "MyWorkflow", state: 'running')
+        workflow_failed = MockWorkflow.new(id: @workflow_id, klass: "MyWorkflow", state: 'failed', finished_at: @frozen_time)
 
-  Time.stub :current, @frozen_time do
-    sequence = Mocha::Sequence.new('failure_cascade')
+        Time.stub :current, @frozen_time do
+          sequence = Mocha::Sequence.new('failure_cascade')
 
-    # Expectations for step_finished(A)
-    repo.expects(:find_step).with(@step_a_id).returns(step_a_failed).in_sequence(sequence)
-    repo.expects(:get_step_dependents).with(@step_a_id).returns([@step_b_id]).in_sequence(sequence) # B depends on A
+          # Expectations for step_finished(A)
+          repo.expects(:find_step).with(@step_a_id).returns(step_a_failed).in_sequence(sequence)
+          repo.expects(:get_step_dependents).with(@step_a_id).returns([@step_b_id]).in_sequence(sequence) # B depends on A
 
-    # Expectations for process_dependents (Optimized Failure Path)
-    # 1. Bulk fetch dependencies for dependents [B]
-    repo.expects(:get_step_dependencies_multi).with([@step_b_id]).returns({ @step_b_id => [@step_a_id] }).in_sequence(sequence)
-    # 2. Bulk fetch states for parents [A] AND dependents [B] (Corrected Args/Return)
-    repo.expects(:fetch_step_states)
-        # --- FIX: Use block constraint to match array content ignoring order ---
-        .with() { |actual_ids| actual_ids.sort == [@step_a_id, @step_b_id].sort }
-        # --- END FIX ---
-        .returns({@step_a_id => 'failed', @step_b_id => 'pending'}) # Need state of B too
-        .in_sequence(sequence)
+          # Expectations for process_dependents (Optimized Failure Path)
+          # 1. Bulk fetch dependencies for dependents [B]
+          repo.expects(:get_step_dependencies_multi).with([@step_b_id]).returns({ @step_b_id => [@step_a_id] }).in_sequence(sequence)
+          # 2. Bulk fetch states for parents [A] AND dependents [B] (Corrected Args/Return)
+          repo.expects(:fetch_step_states)
+          # --- FIX: Use block constraint to match array content ignoring order ---
+            .with() { |actual_ids| actual_ids.sort == [@step_a_id, @step_b_id].sort }
+          # --- END FIX ---
+            .returns({@step_a_id => 'failed', @step_b_id => 'pending'}) # Need state of B too
+            .in_sequence(sequence)
 
-    # 3. Enter 'else' block because A failed, call cancel_downstream_pending(B)
-    #    Note: find_step(B) is NOT called here anymore because state is pre-fetched
+          # 3. Enter 'else' block because A failed, call cancel_downstream_pending(B)
+          #    Note: find_step(B) is NOT called here anymore because state is pre-fetched
 
-    # Expectations for cancel_downstream_pending(B)
-    # It uses the pre-fetched state ('pending')
-    repo.expects(:update_step_attributes)
-        .with(@step_b_id, { state: StateMachine::CANCELLED.to_s, finished_at: @frozen_time }, expected_old_state: StateMachine::PENDING)
-        .returns(true).in_sequence(sequence)
-    repo.expects(:find_step).with(@step_b_id).returns(step_b_cancelled).in_sequence(sequence) # Inside cancel(B) for event payload
-    notifier.expects(:publish).with('yantra.step.cancelled', has_entries(step_id: @step_b_id)).in_sequence(sequence)
-    repo.expects(:get_step_dependents).with(@step_b_id).returns([@step_c_id]).in_sequence(sequence) # Inside cancel(B), find C
+          # Expectations for cancel_downstream_pending(B)
+          # It uses the pre-fetched state ('pending')
+          repo.expects(:update_step_attributes)
+            .with(@step_b_id, { state: StateMachine::CANCELLED.to_s, finished_at: @frozen_time }, expected_old_state: StateMachine::PENDING)
+            .returns(true).in_sequence(sequence)
+          repo.expects(:find_step).with(@step_b_id).returns(step_b_cancelled).in_sequence(sequence) # Inside cancel(B) for event payload
+          notifier.expects(:publish).with('yantra.step.cancelled', has_entries(step_id: @step_b_id)).in_sequence(sequence)
+          repo.expects(:get_step_dependents).with(@step_b_id).returns([@step_c_id]).in_sequence(sequence) # Inside cancel(B), find C
 
-    # Expectations for recursive call cancel_downstream_pending(C)
-    # Fetch state for C because it wasn't in the initial bulk fetch triggered by A's dependents
-    repo.expects(:find_step).with(@step_c_id).returns(step_c_pending).in_sequence(sequence) # Inside cancel(C)
-    repo.expects(:update_step_attributes)
-        .with(@step_c_id, { state: StateMachine::CANCELLED.to_s, finished_at: @frozen_time }, expected_old_state: StateMachine::PENDING)
-        .returns(true).in_sequence(sequence)
-    repo.expects(:find_step).with(@step_c_id).returns(step_c_cancelled).in_sequence(sequence) # Inside cancel(C) for event payload
-    notifier.expects(:publish).with('yantra.step.cancelled', has_entries(step_id: @step_c_id)).in_sequence(sequence)
-    repo.expects(:get_step_dependents).with(@step_c_id).returns([]).in_sequence(sequence) # Inside cancel(C), find no dependents
+          # Expectations for recursive call cancel_downstream_pending(C)
+          # Fetch state for C because it wasn't in the initial bulk fetch triggered by A's dependents
+          repo.expects(:find_step).with(@step_c_id).returns(step_c_pending).in_sequence(sequence) # Inside cancel(C)
+          repo.expects(:update_step_attributes)
+            .with(@step_c_id, { state: StateMachine::CANCELLED.to_s, finished_at: @frozen_time }, expected_old_state: StateMachine::PENDING)
+            .returns(true).in_sequence(sequence)
+          repo.expects(:find_step).with(@step_c_id).returns(step_c_cancelled).in_sequence(sequence) # Inside cancel(C) for event payload
+          notifier.expects(:publish).with('yantra.step.cancelled', has_entries(step_id: @step_c_id)).in_sequence(sequence)
+          repo.expects(:get_step_dependents).with(@step_c_id).returns([]).in_sequence(sequence) # Inside cancel(C), find no dependents
 
-    # Expectations for check_workflow_completion (called after A finishes)
-    repo.expects(:running_step_count).with(@workflow_id).returns(0).in_sequence(sequence)
-    repo.expects(:enqueued_step_count).with(@workflow_id).returns(0).in_sequence(sequence)
-    repo.expects(:find_workflow).with(@workflow_id).returns(workflow_running).in_sequence(sequence) # Check if terminal
-    repo.expects(:workflow_has_failures?).with(@workflow_id).returns(true).in_sequence(sequence) # Assume flag was set
-    repo.expects(:update_workflow_attributes) # Update to failed
-        .with(@workflow_id, has_entries(state: StateMachine::FAILED.to_s), expected_old_state: StateMachine::RUNNING)
-        .returns(true).in_sequence(sequence)
-    repo.expects(:find_workflow).with(@workflow_id).returns(workflow_failed).in_sequence(sequence) # For event payload
-    notifier.expects(:publish).with('yantra.workflow.failed', has_entries(workflow_id: @workflow_id, state: :failed)).in_sequence(sequence)
+          # Expectations for check_workflow_completion (called after A finishes)
+          repo.expects(:running_step_count).with(@workflow_id).returns(0).in_sequence(sequence)
+          repo.expects(:enqueued_step_count).with(@workflow_id).returns(0).in_sequence(sequence)
+          repo.expects(:find_workflow).with(@workflow_id).returns(workflow_running).in_sequence(sequence) # Check if terminal
+          repo.expects(:workflow_has_failures?).with(@workflow_id).returns(true).in_sequence(sequence) # Assume flag was set
+          repo.expects(:update_workflow_attributes) # Update to failed
+            .with(@workflow_id, has_entries(state: StateMachine::FAILED.to_s), expected_old_state: StateMachine::RUNNING)
+            .returns(true).in_sequence(sequence)
+          repo.expects(:find_workflow).with(@workflow_id).returns(workflow_failed).in_sequence(sequence) # For event payload
+          notifier.expects(:publish).with('yantra.workflow.failed', has_entries(workflow_id: @workflow_id, state: :failed)).in_sequence(sequence)
 
-    # Act
-    orchestrator.step_finished(@step_a_id)
-    # Assertions handled by mock verification
-  end
-end
+          # Act
+          orchestrator.step_finished(@step_a_id)
+          # Assertions handled by mock verification
+        end
+      end
 
 
 

--- a/test/core/orchestrator_test.rb
+++ b/test/core/orchestrator_test.rb
@@ -61,6 +61,8 @@ module Yantra
         # Also stub is_a? in case other parts rely on it
         notifier.stubs(:is_a?).with(Yantra::Events::NotifierInterface).returns(true)
 
+        repo.stubs(:respond_to?).with(:get_step_dependencies_multi).returns(true)
+        repo.stubs(:respond_to?).with(:fetch_step_states).returns(true)
 
         # Local orchestrator instance with Mocha mocks
         orchestrator = Orchestrator.new(repository: repo, worker_adapter: worker, notifier: notifier)
@@ -72,78 +74,59 @@ module Yantra
       def test_start_workflow_enqueues_multiple_initial_jobs
         mocks = setup_mocha_mocks_and_orchestrator
         repo = mocks[:repo]; worker = mocks[:worker]; notifier = mocks[:notifier]; orchestrator = mocks[:orchestrator]
-        sequence = Mocha::Sequence.new('start_workflow_enqueues_multiple_initial_jobs')
+        ready_step_ids = [@step_a_id, @step_b_id]
+        workflow_running = MockWorkflow.new(id: @workflow_id, klass: "TestWorkflow", state: 'running', started_at: @frozen_time)
+        step_a_pending = MockStep.new(id: @step_a_id, workflow_id: @workflow_id, klass: "StepA", state: 'pending', queue: 'q1')
+        step_b_pending = MockStep.new(id: @step_b_id, workflow_id: @workflow_id, klass: "StepB", state: 'pending', queue: 'q2')
+        step_a_enqueued = MockStep.new(id: @step_a_id, workflow_id: @workflow_id, klass: "StepA", state: 'enqueued', queue: 'q1', enqueued_at: @frozen_time)
+        step_b_enqueued = MockStep.new(id: @step_b_id, workflow_id: @workflow_id, klass: "StepB", state: 'enqueued', queue: 'q2', enqueued_at: @frozen_time)
 
         Time.stub :current, @frozen_time do
-          # Mock data needed for test setup and returns
-          workflow_running = MockWorkflow.new(id: @workflow_id, klass: "TestWorkflow", state: 'running', started_at: @frozen_time)
-          initial_step_a = MockStep.new(id: @step_a_id, workflow_id: @workflow_id, klass: "StepA", state: 'pending', queue: "q1")
-          initial_step_b = MockStep.new(id: @step_b_id, workflow_id: @workflow_id, klass: "StepB", state: 'pending', queue: "q2")
-          # Mock records after update for event payloads
-          step_a_enqueued = MockStep.new(id: @step_a_id, workflow_id: @workflow_id, klass: "StepA", state: 'enqueued', queue: "q1", enqueued_at: @frozen_time)
-          step_b_enqueued = MockStep.new(id: @step_b_id, workflow_id: @workflow_id, klass: "StepB", state: 'enqueued', queue: "q2", enqueued_at: @frozen_time)
+          sequence = Mocha::Sequence.new('start_workflow_enqueues_multiple_initial_jobs')
 
-          # --- Mocha Expectations (Corrected Sequence v32) ---
-          # 1. Expect workflow update to running
-          repo.expects(:update_workflow_attributes).with(
-            @workflow_id,
-            has_entries(state: StateMachine::RUNNING.to_s, started_at: @frozen_time),
-            expected_old_state: StateMachine::PENDING
-          ).returns(true).in_sequence(sequence)
-
-          # 2. Expect find_workflow for the 'workflow started' event payload
+          # Expectations for start_workflow
+          repo.expects(:update_workflow_attributes)
+            .with(@workflow_id, { state: StateMachine::RUNNING.to_s, started_at: @frozen_time }, expected_old_state: StateMachine::PENDING)
+            .returns(true).in_sequence(sequence)
           repo.expects(:find_workflow).with(@workflow_id).returns(workflow_running).in_sequence(sequence)
-          # 3. Expect the 'workflow started' publish call
-          notifier.expects(:publish).with(
-            'yantra.workflow.started',
-            has_entries(workflow_id: @workflow_id, state: StateMachine::RUNNING)
-          ).returns(nil).in_sequence(sequence)
+          # --- FIX: Correct payload expectation ---
+          notifier.expects(:publish)
+            .with('yantra.workflow.started', has_entries(workflow_id: @workflow_id, klass: "TestWorkflow", started_at: @frozen_time))
+            .in_sequence(sequence)
+          # --- END FIX ---
+          repo.expects(:find_ready_steps).with(@workflow_id).returns(ready_step_ids).in_sequence(sequence)
 
-          # 4. Expect find_ready_jobs
-          repo.expects(:find_ready_steps).with(@workflow_id).returns([@step_a_id, @step_b_id]).in_sequence(sequence)
+          # Expectations for the loop calling enqueue_step(A) and enqueue_step(B)
+          # Note: The actual order of A vs B might vary, sequences can be tricky here.
+          # If this still fails on order, we might need to remove the sequence for the enqueue part.
 
-          # 5. Process Step A
-          repo.expects(:find_step).with(@step_a_id).returns(initial_step_a).in_sequence(sequence)
-          repo.expects(:update_step_attributes).with(
-            @step_a_id,
-            has_entries(state: StateMachine::ENQUEUED.to_s, enqueued_at: @frozen_time),
-            expected_old_state: StateMachine::PENDING
-          ).returns(true).in_sequence(sequence) # Update A
-          worker.expects(:enqueue).with(@step_a_id, @workflow_id, "StepA", "q1").returns(nil).in_sequence(sequence) # Enqueue A
-          # --- FIX: Add expectations for step A enqueued event ---
-          repo.expects(:find_step).with(@step_a_id).returns(step_a_enqueued).in_sequence(sequence)
-          notifier.expects(:publish).with(
-            'yantra.step.enqueued',
-            has_entries(step_id: @step_a_id, queue: "q1", enqueued_at: @frozen_time)
-          ).returns(nil).in_sequence(sequence) # Publish A enqueued
-          # --- End FIX ---
+          # enqueue_step(A) calls:
+          repo.expects(:find_step).with(@step_a_id).returns(step_a_pending).in_sequence(sequence) # Start of enqueue_step
+          # --- FIX: Use keyword argument ---
+          repo.expects(:update_step_attributes)
+            .with(@step_a_id, has_entries(state: "enqueued"), expected_old_state: :pending)
+            .returns(true).in_sequence(sequence)
+          # --- END FIX ---
+          repo.expects(:find_step).with(@step_a_id).returns(step_a_enqueued).in_sequence(sequence) # For payload/worker
+          notifier.expects(:publish).with('yantra.step.enqueued', has_entries(step_id: @step_a_id, queue: "q1")).in_sequence(sequence)
+          worker.expects(:enqueue).with(@step_a_id, @workflow_id, "StepA", "q1").in_sequence(sequence)
 
-          # 6. Process Step B
-          repo.expects(:find_step).with(@step_b_id).returns(initial_step_b).in_sequence(sequence) # Find B (1st time)
-          repo.expects(:update_step_attributes).with(
-            @step_b_id,
-            has_entries(state: StateMachine::ENQUEUED.to_s, enqueued_at: @frozen_time),
-            expected_old_state: StateMachine::PENDING
-          ).returns(true).in_sequence(sequence) # Update B
-          worker.expects(:enqueue).with(@step_b_id, @workflow_id, "StepB", "q2").returns(nil).in_sequence(sequence) # Enqueue B
-          # --- FIX: Add expectations for step B enqueued event ---
-          repo.expects(:find_step).with(@step_b_id).returns(step_b_enqueued).in_sequence(sequence) # Find B (2nd time, for event)
-          notifier.expects(:publish).with(
-            'yantra.step.enqueued',
-            has_entries(step_id: @step_b_id, queue: "q2", enqueued_at: @frozen_time)
-          ).returns(nil).in_sequence(sequence) # Publish B enqueued
-          # --- End FIX ---
-          # --- End Mocha Expectations ---
+          # enqueue_step(B) calls:
+          repo.expects(:find_step).with(@step_b_id).returns(step_b_pending).in_sequence(sequence) # Start of enqueue_step
+          # --- FIX: Use keyword argument ---
+          repo.expects(:update_step_attributes)
+            .with(@step_b_id, has_entries(state: "enqueued"), expected_old_state: :pending)
+            .returns(true).in_sequence(sequence)
+          # --- END FIX ---
+          repo.expects(:find_step).with(@step_b_id).returns(step_b_enqueued).in_sequence(sequence) # For payload/worker
+          notifier.expects(:publish).with('yantra.step.enqueued', has_entries(step_id: @step_b_id, queue: "q2")).in_sequence(sequence)
+          worker.expects(:enqueue).with(@step_b_id, @workflow_id, "StepB", "q2").in_sequence(sequence)
 
           # Act
-          result = orchestrator.start_workflow(@workflow_id)
-          assert result
+          orchestrator.start_workflow(@workflow_id)
+          # Assertions handled by mock verification
         end
       end
-
-
-
-
 
       # =========================================================================
       def test_start_workflow_does_nothing_if_not_pending
@@ -171,85 +154,184 @@ module Yantra
 
       # --- Test step_succeeded ---
       # (Converted to Mocha - Corrected v21: Match orchestrator event payload)
-      def test_step_succeeded_updates_state_and_calls_step_finished_and_publishes_event
+      # test/core/orchestrator_test.rb (Specific Test - Fixed)
+      def test_step_succeeded_updates_state_records_output_publishes_event_and_calls_step_finished
         mocks = setup_mocha_mocks_and_orchestrator
         repo = mocks[:repo]; notifier = mocks[:notifier]; orchestrator = mocks[:orchestrator]
-        sequence = Mocha::Sequence.new('step_succeeded_updates_state')
+        output = { result: "ok" }
+        step_succeeded_record = MockStep.new(id: @step_a_id, workflow_id: @workflow_id, klass: "StepA", state: 'succeeded', finished_at: @frozen_time, output: output)
 
         Time.stub :current, @frozen_time do
-          result_output = { message: "Done" }
-          step_a_updated = MockStep.new(id: @step_a_id, workflow_id: @workflow_id, klass: "StepA", state: 'succeeded', output: result_output, finished_at: @frozen_time)
-
-          # Mocha Expectations
-          repo.expects(:update_step_attributes).with(
-            @step_a_id,
-            has_entries(state: StateMachine::SUCCEEDED.to_s, output: result_output, finished_at: @frozen_time),
-            { expected_old_state: StateMachine::RUNNING }
-          ).returns(true).in_sequence(sequence)
-          repo.expects(:find_step).with(@step_a_id).returns(step_a_updated).in_sequence(sequence)
-          notifier.expects(:publish).with(
-            'yantra.step.succeeded',
-            has_entries(
-              step_id: @step_a_id,
-              workflow_id: @workflow_id,
-              klass: "StepA",
-              finished_at: @frozen_time,
-              output: result_output
+          # Expectations for step_succeeded itself
+          # --- FIX: Use keyword argument for expected_old_state ---
+          repo.expects(:update_step_attributes)
+            .with(
+              @step_a_id, # Positional arg 1
+              { state: StateMachine::SUCCEEDED.to_s, finished_at: @frozen_time }, # Positional arg 2
+              expected_old_state: StateMachine::RUNNING # Keyword arg
             )
-          ).returns(nil).in_sequence(sequence)
-          orchestrator.expects(:step_finished).with(@step_a_id).returns(nil).in_sequence(sequence)
+              .returns(true)
+            # --- END FIX ---
 
-          # Act
-          orchestrator.step_succeeded(@step_a_id, result_output)
+            repo.expects(:record_step_output).with(@step_a_id, output).returns(true)
+            repo.expects(:find_step).with(@step_a_id).returns(step_succeeded_record) # For event payload
+            notifier.expects(:publish).with('yantra.step.succeeded', has_entries(step_id: @step_a_id, output: output))
+
+            # Expect step_finished to be called internally
+            orchestrator.expects(:step_finished).with(@step_a_id)
+
+            # Act
+            orchestrator.step_succeeded(@step_a_id, output)
+            # Assertions are handled by mock verification
         end
       end
 
+      # test/core/orchestrator_test.rb (Specific Test - Corrected Count)
       def test_enqueue_step_handles_update_failure
+        mocks = setup_mocha_mocks_and_orchestrator
+        repo = mocks[:repo]; worker = mocks[:worker]; notifier = mocks[:notifier]; orchestrator = mocks[:orchestrator]
+        step_pending = MockStep.new(id: @step_a_id, workflow_id: @workflow_id, klass: "StepA", state: 'pending')
+
+        # Expectations: Simulate update_step_attributes returning false
+        # Expect find_step to be called ONCE at the beginning of enqueue_step
+        repo.expects(:find_step).with(@step_a_id).returns(step_pending).once # <<< FIX: Expect only once
+
+        # Expect update_step_attributes to be called and fail
+        repo.expects(:update_step_attributes)
+          .with(
+            @step_a_id,
+            has_entries(state: StateMachine::ENQUEUED.to_s), # Time check removed earlier
+            expected_old_state: StateMachine::PENDING
+          )
+            .returns(false)
+
+          # DO NOT expect event publish or worker enqueue because the method returns early
+          notifier.expects(:publish).never
+          worker.expects(:enqueue).never
+
+          # Act: Call the private method under test
+          orchestrator.send(:enqueue_step, @step_a_id)
+          # Assertions handled by mock verification
+      end
+
+
+
+      def test_step_succeeded_updates_state_records_output_publishes_event_and_calls_step_finished
+        mocks = setup_mocha_mocks_and_orchestrator
+        repo = mocks[:repo]; notifier = mocks[:notifier]; orchestrator = mocks[:orchestrator]
+        output = { result: "ok" }
+        step_succeeded_record = MockStep.new(id: @step_a_id, workflow_id: @workflow_id, klass: "StepA", state: 'succeeded', finished_at: @frozen_time, output: output)
+
+        Time.stub :current, @frozen_time do
+          # Expectations for step_succeeded itself
+          repo.expects(:update_step_attributes)
+            .with(@step_a_id, { state: StateMachine::SUCCEEDED.to_s, finished_at: @frozen_time }, { expected_old_state: StateMachine::RUNNING })
+            .returns(true)
+          repo.expects(:record_step_output).with(@step_a_id, output).returns(true) # Assume output recording succeeds
+          repo.expects(:find_step).with(@step_a_id).returns(step_succeeded_record) # For event payload
+          notifier.expects(:publish).with('yantra.step.succeeded', has_entries(step_id: @step_a_id, output: output))
+
+          # Expect step_finished to be called internally
+          orchestrator.expects(:step_finished).with(@step_a_id)
+
+          # Act
+          orchestrator.step_succeeded(@step_a_id, output)
+          # Assertions are handled by mock verification
+        end
+      end
+
+      # --- Test step_finished ---
+
+      # --- UPDATED: Reworked expectations for fetch_step_states ---
+      # test/core/orchestrator_test.rb (Specific Test - Fixed Expectations for Optimized Path)
+      def test_step_finished_success_enqueues_ready_dependent
+        mocks = setup_mocha_mocks_and_orchestrator
+        repo = mocks[:repo]; notifier = mocks[:notifier]; worker = mocks[:worker]; orchestrator = mocks[:orchestrator]
+        # Setup: Step A succeeded, Step B depends on A and is pending
+        step_a_succeeded = MockStep.new(id: @step_a_id, workflow_id: @workflow_id, state: 'succeeded')
+        step_b_pending = MockStep.new(id: @step_b_id, workflow_id: @workflow_id, klass: "StepB", state: 'pending', queue: 'q_b')
+        step_b_enqueued = MockStep.new(id: @step_b_id, workflow_id: @workflow_id, klass: "StepB", state: 'enqueued', queue: 'q_b', enqueued_at: @frozen_time)
+
+        Time.stub :current, @frozen_time do
+          # --- Re-introduce Sequence ---
+          sequence = Mocha::Sequence.new('step_finished_success_enqueues')
+
+          # Expectations for step_finished(A)
+          repo.expects(:find_step).with(@step_a_id).returns(step_a_succeeded).in_sequence(sequence)
+          repo.expects(:get_step_dependents).with(@step_a_id).returns([@step_b_id]).in_sequence(sequence) # B depends on A
+
+          # Expectations for process_dependents (Optimized Success Path)
+          repo.expects(:get_step_dependencies_multi).with([@step_b_id]).returns({ @step_b_id => [@step_a_id] }).in_sequence(sequence)
+          repo.expects(:fetch_step_states).with([@step_a_id]).returns({ @step_a_id => 'succeeded' }).in_sequence(sequence)
+
+          # Expectations for is_ready_to_start?(B)
+          repo.expects(:find_step).with(@step_b_id).returns(step_b_pending).in_sequence(sequence) # Call 1 for find_step(B)
+
+          # Expectations for enqueue_step(B) because it's ready
+          repo.expects(:find_step).with(@step_b_id).returns(step_b_pending).in_sequence(sequence) # Call 2 for find_step(B) (start of enqueue_step)
+          repo.expects(:update_step_attributes)
+            .with(@step_b_id, has_entries(state: StateMachine::ENQUEUED.to_s), expected_old_state: StateMachine::PENDING)
+            .returns(true).in_sequence(sequence)
+          repo.expects(:find_step).with(@step_b_id).returns(step_b_enqueued).in_sequence(sequence) # Call 3 for find_step(B) (for payload/enqueue)
+          notifier.expects(:publish).with('yantra.step.enqueued', has_entries(step_id: @step_b_id)).in_sequence(sequence)
+          worker.expects(:enqueue).with(@step_b_id, @workflow_id, "StepB", "q_b").in_sequence(sequence)
+
+          # Expectations for check_workflow_completion
+          repo.expects(:running_step_count).with(@workflow_id).returns(0).in_sequence(sequence)
+          repo.expects(:enqueued_step_count).with(@workflow_id).returns(1).in_sequence(sequence) # B is now enqueued
+
+          # Act
+          orchestrator.step_finished(@step_a_id)
+          # Assertions handled by mock verification
+        end
+      end
+
+      # --- UPDATED: Reworked expectations ---
+      # test/core/orchestrator_test.rb (Specific Test - Fixed Expectations)
+
+def test_step_finished_success_does_not_enqueue_if_deps_not_met
   mocks = setup_mocha_mocks_and_orchestrator
-  repo = mocks[:repo]; orchestrator = mocks[:orchestrator]; notifier = mocks[:notifier]
-  # No sequence needed, just verify the update fails
+  repo = mocks[:repo]; notifier = mocks[:notifier]; orchestrator = mocks[:orchestrator] # Added notifier
+  # Setup: A succeeded, C depends on A & B, B is still pending
+  step_a_succeeded = MockStep.new(id: @step_a_id, workflow_id: @workflow_id, state: 'succeeded', klass: "StepA")
+  step_b_pending = MockStep.new(id: @step_b_id, workflow_id: @workflow_id, state: 'pending')
+  step_c_pending = MockStep.new(id: @step_c_id, workflow_id: @workflow_id, state: 'pending', klass: "StepC")
+  workflow_running = MockWorkflow.new(id: @workflow_id, klass: "MyWorkflow", state: 'running')
+  workflow_succeeded = MockWorkflow.new(id: @workflow_id, klass: "MyWorkflow", state: 'succeeded', finished_at: @frozen_time)
 
   Time.stub :current, @frozen_time do
-    initial_job = MockStep.new(id: @step_a_id, workflow_id: @workflow_id, klass: "StepA", state: 'pending') # Data only
-    # Mock workflow record needed for the publish call in start_workflow
-    workflow_running = MockWorkflow.new(id: @workflow_id, klass: "TestWorkflow", state: 'running', started_at: @frozen_time)
+    sequence = Mocha::Sequence.new('step_finished_deps_not_met_completes')
 
+    # Expectations for step_finished(A)
+    repo.expects(:find_step).with(@step_a_id).returns(step_a_succeeded).in_sequence(sequence)
+    repo.expects(:get_step_dependents).with(@step_a_id).returns([@step_c_id]).in_sequence(sequence) # C depends on A
 
-    # --- Mocha Expectations (Corrected v36) ---
-    # 1. Stub workflow update to allow start_workflow to proceed
-    repo.stubs(:update_workflow_attributes)
-        .with(@workflow_id, has_key(:state), has_key(:expected_old_state))
-        .returns(true)
+    # --- Expectations for process_dependents (Optimized Success Path) ---
+    # 1. Bulk fetch dependencies for dependents [C]
+    repo.expects(:get_step_dependencies_multi).with([@step_c_id]).returns({ @step_c_id => [@step_a_id, @step_b_id] }).in_sequence(sequence) # <<< CORRECTED EXPECTATION
+    # 2. Bulk fetch states for parents [A, B]
+    repo.expects(:fetch_step_states).with([@step_a_id, @step_b_id]).returns({ @step_a_id => 'succeeded', @step_b_id => 'pending' }).in_sequence(sequence)
+    # 3. Check C's current state (inside is_ready_to_start?)
+    repo.expects(:find_step).with(@step_c_id).returns(step_c_pending).in_sequence(sequence)
+    # Note: enqueue_step(C) is NOT called because B is pending
+    # --- End process_dependents expectations ---
 
-    # 2. Expect find_workflow for the 'workflow started' event payload
-    repo.expects(:find_workflow).with(@workflow_id).returns(workflow_running)
-    # 3. Expect the 'workflow started' publish call
-    notifier.expects(:publish).with(
-        'yantra.workflow.started',
-        has_entries(workflow_id: @workflow_id, state: StateMachine::RUNNING)
-        ).returns(nil)
-
-    # --- FIX: Add missing expectations ---
-    # 4. Expect find_ready_steps
-    repo.expects(:find_ready_steps).with(@workflow_id).returns([@step_a_id])
-    # 5. Expect find_step (for enqueue_job)
-    repo.expects(:find_step).with(@step_a_id).returns(initial_job)
-    # --- End FIX ---
-
-    # 6. Expect step update to FAIL
-    repo.expects(:update_step_attributes).with(
-      @step_a_id,
-      # FIX: Expect the attributes the code actually tries to set
-      has_entries(state: StateMachine::ENQUEUED.to_s, enqueued_at: @frozen_time),
-      expected_old_state: StateMachine::PENDING
-    ).returns(false) # <<< Key expectation: Simulate failure
-    # --- End Mocha Expectations ---
+    # --- Expectations for check_workflow_completion ---
+    repo.expects(:running_step_count).with(@workflow_id).returns(0).in_sequence(sequence)
+    repo.expects(:enqueued_step_count).with(@workflow_id).returns(0).in_sequence(sequence) # Nothing got enqueued
+    repo.expects(:find_workflow).with(@workflow_id).returns(workflow_running).in_sequence(sequence) # Check if terminal
+    repo.expects(:workflow_has_failures?).with(@workflow_id).returns(false).in_sequence(sequence) # No failures
+    # Update workflow to succeeded (FIX: Use keyword arg)
+    repo.expects(:update_workflow_attributes)
+        .with(@workflow_id, { state: StateMachine::SUCCEEDED.to_s, finished_at: @frozen_time }, expected_old_state: StateMachine::RUNNING)
+        .returns(true).in_sequence(sequence)
+    repo.expects(:find_workflow).with(@workflow_id).returns(workflow_succeeded).in_sequence(sequence) # For event payload
+    notifier.expects(:publish).with('yantra.workflow.succeeded', has_entries(workflow_id: @workflow_id, state: :succeeded)).in_sequence(sequence)
+    # --- End check_workflow_completion expectations ---
 
     # Act
-    orchestrator.start_workflow(@workflow_id)
-
-    # Assert: Verification of expects happens automatically.
-    # We implicitly assert that no error was raised and worker.enqueue was not called.
+    orchestrator.step_finished(@step_a_id)
+    # Assertions handled by mock verification
   end
 end
 
@@ -257,249 +339,104 @@ end
 
 
 
-      # --- Test step_failed ---
-      # (Converted to Mocha)
-      def test_step_failed_calls_step_finished
-        mocks = setup_mocha_mocks_and_orchestrator
-        orchestrator = mocks[:orchestrator]
-        sequence = Mocha::Sequence.new('step_failed_calls_step_finished')
-
-        # Mocha Expectation
-        orchestrator.expects(:step_finished).with(@step_a_id).returns(nil).in_sequence(sequence)
-
-        # Act
-        orchestrator.step_failed(@step_a_id)
-      end
-
-      # --- Test step_finished (Success Path) ---
-
-      # =========================================================================
-      # MOCHA TEST - Using Sequence (Corrected v23)
-      # =========================================================================
-      def test_step_finished_success_enqueues_ready_dependent
-        mocks = setup_mocha_mocks_and_orchestrator
-        repo = mocks[:repo]; worker = mocks[:worker]; notifier = mocks[:notifier]; orchestrator = mocks[:orchestrator]
-        sequence = Mocha::Sequence.new('step_finished_success_enqueues_ready_dependent')
-
-        Time.stub :current, @frozen_time do
-          step_a = MockStep.new(id: @step_a_id, workflow_id: @workflow_id, klass: "StepA", state: 'succeeded')
-          step_b = MockStep.new(id: @step_b_id, workflow_id: @workflow_id, klass: "StepB", state: 'pending', queue: 'default')
-          # Mock step B record after update for event payload
-          step_b_enqueued = MockStep.new(id: @step_b_id, workflow_id: @workflow_id, klass: "StepB", state: 'enqueued', queue: 'default', enqueued_at: @frozen_time)
-
-
-          # --- Mocha Expectations (Corrected Sequence v27) ---
-          repo.expects(:find_step).with(@step_a_id).returns(step_a).in_sequence(sequence) # In step_finished
-          repo.expects(:get_step_dependents).with(@step_a_id).returns([@step_b_id]).in_sequence(sequence) # In process_dependents
-          repo.expects(:find_step).with(@step_b_id).returns(step_b).in_sequence(sequence) # In process_dependents (find B)
-          # Should check dependencies now
-          repo.expects(:get_step_dependencies).with(@step_b_id).returns([@step_a_id]).in_sequence(sequence) # In dependencies_met?
-          repo.expects(:find_step).with(@step_a_id).returns(step_a).in_sequence(sequence) # In dependencies_met? (Check A state)
-          # Should enqueue B
-          repo.expects(:find_step).with(@step_b_id).returns(step_b).in_sequence(sequence) # In enqueue_step (find B before update)
-          repo.expects(:update_step_attributes).with(
-            @step_b_id,
-            has_entries(state: StateMachine::ENQUEUED.to_s, enqueued_at: @frozen_time),
-            { expected_old_state: StateMachine::PENDING }
-          ).returns(true).in_sequence(sequence) # In enqueue_step
-          # Enqueue call happens next
-          worker.expects(:enqueue).with(@step_b_id, @workflow_id, "StepB", "default").returns(nil).in_sequence(sequence) # In enqueue_step
-          # --- FIX: Add expectations for event publishing inside enqueue_step ---
-          repo.expects(:find_step).with(@step_b_id).returns(step_b_enqueued).in_sequence(sequence) # In enqueue_step (after enqueue for event)
-          notifier.expects(:publish).with(
-            'yantra.step.enqueued',
-            has_entries(step_id: @step_b_id, enqueued_at: @frozen_time, queue: 'default')
-          ).in_sequence(sequence) # In enqueue_step
-          # --- End FIX ---
-          # Should check workflow completion AFTER enqueue attempt block finishes
-          repo.expects(:running_step_count).with(@workflow_id).returns(0).in_sequence(sequence) # In check_workflow_completion
-          repo.expects(:enqueued_step_count).with(@workflow_id).returns(1).in_sequence(sequence) # In check_workflow_completion (B is enqueued)
-          # --- End Mocha Expectations ---
-
-          orchestrator.step_finished(@step_a_id)
-        end
-      end
-
-
-      # =========================================================================
-      # MOCHA TEST - Using Sequence
-      # =========================================================================
-      def test_step_finished_success_does_not_enqueue_if_deps_not_met
-        mocks = setup_mocha_mocks_and_orchestrator
-        repo = mocks[:repo]; notifier = mocks[:notifier]; orchestrator = mocks[:orchestrator]
-        sequence = Mocha::Sequence.new('step_finished_success_does_not_enqueue')
-
-        Time.stub :current, @frozen_time do
-          step_a = MockStep.new(id: @step_a_id, workflow_id: @workflow_id, klass: "StepA", state: 'succeeded')
-          step_b = MockStep.new(id: @step_b_id, workflow_id: @workflow_id, klass: "StepB", state: 'pending')
-          step_c = MockStep.new(id: @step_c_id, workflow_id: @workflow_id, klass: "StepC", state: 'pending')
-          workflow_succeeded = MockWorkflow.new(id: @workflow_id, klass: "TestWorkflow", state: 'succeeded', finished_at: @frozen_time)
-
-          # --- Mocha Expectations ---
-          repo.expects(:find_step).with(@step_a_id).returns(step_a).in_sequence(sequence) # In step_finished
-          repo.expects(:get_step_dependents).with(@step_a_id).returns([@step_c_id]).in_sequence(sequence) # In process_dependents
-          repo.expects(:find_step).with(@step_c_id).returns(step_c).in_sequence(sequence) # In process_dependents (find C)
-          repo.expects(:get_step_dependencies).with(@step_c_id).returns([@step_a_id, @step_b_id]).in_sequence(sequence) # In dependencies_met?
-          repo.expects(:find_step).with(@step_a_id).returns(step_a).in_sequence(sequence) # In dependencies_met? (Check A state)
-          repo.expects(:find_step).with(@step_b_id).returns(step_b).in_sequence(sequence) # In dependencies_met? (Check B state -> Pending!)
-          # Workflow Completion Checks:
-          repo.expects(:running_step_count).with(@workflow_id).returns(0).in_sequence(sequence) # In check_workflow_completion
-          repo.expects(:enqueued_step_count).with(@workflow_id).returns(0).in_sequence(sequence) # In check_workflow_completion
-          # --- Corrected Sequence for check_workflow_completion ---
-          repo.expects(:workflow_has_failures?).with(@workflow_id).returns(false).in_sequence(sequence)
-          repo.expects(:update_workflow_attributes).with(
-            @workflow_id,
-            has_entries(state: StateMachine::SUCCEEDED.to_s, finished_at: @frozen_time),
-            { expected_old_state: StateMachine::RUNNING }
-          ).returns(true).in_sequence(sequence)
-          repo.expects(:find_workflow).with(@workflow_id).returns(workflow_succeeded).in_sequence(sequence) # Find AFTER update for event
-          # ------------------------------------------------------
-          notifier.expects(:publish).with(
-            'yantra.workflow.succeeded',
-            # Match payload from orchestrator check_workflow_completion
-            has_entries(workflow_id: @workflow_id, state: StateMachine::SUCCEEDED, finished_at: @frozen_time)
-          ).returns(nil).in_sequence(sequence)
-          # --- End Mocha Expectations ---
-
-          orchestrator.step_finished(@step_a_id)
-        end
-      end
-      # =========================================================================
-
-      # =========================================================================
-      # MOCHA TEST - Using Sequence (Corrected)
-      # =========================================================================
-      def test_step_finished_success_completes_workflow_if_last_job
-        mocks = setup_mocha_mocks_and_orchestrator
-        repo = mocks[:repo]; notifier = mocks[:notifier]; orchestrator = mocks[:orchestrator]
-        sequence = Mocha::Sequence.new('step_finished_success_completes')
-
-        Time.stub :current, @frozen_time do
-          step_a = MockStep.new(id: @step_a_id, workflow_id: @workflow_id, klass: "StepA", state: 'succeeded')
-          workflow_succeeded = MockWorkflow.new(id: @workflow_id, klass: "TestWorkflow", state: 'succeeded', started_at: @frozen_time - 10, finished_at: @frozen_time, has_failures: false)
-
-          # --- Mocha Expectations ---
-          repo.expects(:find_step).with(@step_a_id).returns(step_a).in_sequence(sequence)
-          repo.expects(:get_step_dependents).with(@step_a_id).returns([]).in_sequence(sequence)
-          repo.expects(:running_step_count).with(@workflow_id).returns(0).in_sequence(sequence)
-          repo.expects(:enqueued_step_count).with(@workflow_id).returns(0).in_sequence(sequence)
-          # --- Corrected Sequence for check_workflow_completion ---
-          repo.expects(:workflow_has_failures?).with(@workflow_id).returns(false).in_sequence(sequence)
-          repo.expects(:update_workflow_attributes).with(
-            @workflow_id,
-            has_entries(state: StateMachine::SUCCEEDED.to_s, finished_at: @frozen_time),
-            { expected_old_state: StateMachine::RUNNING }
-          ).returns(true).in_sequence(sequence)
-          repo.expects(:find_workflow).with(@workflow_id).returns(workflow_succeeded).in_sequence(sequence)
-          # ------------------------------------------------------
-          notifier.expects(:publish).with(
-            'yantra.workflow.succeeded',
-            # Match payload from orchestrator check_workflow_completion
-            has_entries(
-              workflow_id: @workflow_id,
-              state: StateMachine::SUCCEEDED, # Use constant symbol
-              finished_at: @frozen_time
-            )
-          ).returns(nil).in_sequence(sequence)
-          # --- End Mocha Expectations ---
-
-          orchestrator.step_finished(@step_a_id)
-        end
-      end
-      # =========================================================================
-
-
-      # =========================================================================
-      # MOCHA TEST - Using Sequence (Corrected)
-      # =========================================================================
+      # --- UPDATED: Reworked expectations ---
       def test_step_finished_failure_completes_workflow_if_last_job
         mocks = setup_mocha_mocks_and_orchestrator
         repo = mocks[:repo]; notifier = mocks[:notifier]; orchestrator = mocks[:orchestrator]
-        sequence = Mocha::Sequence.new('step_finished_failure_completes')
+        # Setup: Step A failed, no dependents
+        step_a_failed = MockStep.new(id: @step_a_id, workflow_id: @workflow_id, klass: "StepA", state: 'failed', finished_at: @frozen_time)
+        final_wf_record = MockWorkflow.new(id: @workflow_id, klass: "MyWorkflow", state: 'failed', finished_at: @frozen_time)
 
         Time.stub :current, @frozen_time do
-          step_a = MockStep.new(id: @step_a_id, workflow_id: @workflow_id, klass: "StepA", state: 'failed')
-          workflow_failed = MockWorkflow.new(id: @workflow_id, klass: "TestWorkflow", state: 'failed', started_at: @frozen_time - 10, finished_at: @frozen_time, has_failures: true)
+          # Expectations for step_finished(A)
+          repo.expects(:find_step).with(@step_a_id).returns(step_a_failed)
+          repo.expects(:get_step_dependents).with(@step_a_id).returns([]) # No dependents
 
-          # --- Mocha Expectations ---
-          repo.expects(:find_step).with(@step_a_id).returns(step_a).in_sequence(sequence)
-          repo.expects(:get_step_dependents).with(@step_a_id).returns([]).in_sequence(sequence)
-          repo.expects(:running_step_count).with(@workflow_id).returns(0).in_sequence(sequence)
-          repo.expects(:enqueued_step_count).with(@workflow_id).returns(0).in_sequence(sequence)
-          # --- Corrected Sequence for check_workflow_completion ---
-          repo.expects(:workflow_has_failures?).with(@workflow_id).returns(true).in_sequence(sequence)
-          repo.expects(:update_workflow_attributes).with(
-            @workflow_id,
-            has_entries(state: StateMachine::FAILED.to_s, finished_at: @frozen_time),
-            { expected_old_state: StateMachine::RUNNING }
-          ).returns(true).in_sequence(sequence)
-          repo.expects(:find_workflow).with(@workflow_id).returns(workflow_failed).in_sequence(sequence)
-          # ------------------------------------------------------
-          notifier.expects(:publish).with(
-            'yantra.workflow.failed',
-            # Match payload from orchestrator check_workflow_completion
-            has_entries(
-              workflow_id: @workflow_id,
-              state: StateMachine::FAILED, # Use constant symbol
-              finished_at: @frozen_time
-            )
-          ).returns(nil).in_sequence(sequence)
-          # --- End Mocha Expectations ---
+          # Expectations for check_workflow_completion
+          repo.expects(:running_step_count).with(@workflow_id).returns(0)
+          repo.expects(:enqueued_step_count).with(@workflow_id).returns(0)
+          repo.expects(:find_workflow).with(@workflow_id).returns(MockWorkflow.new(id: @workflow_id, state: 'running')) # Assume running before check
+          repo.expects(:workflow_has_failures?).with(@workflow_id).returns(true) # Assume flag was set
+          repo.expects(:update_workflow_attributes)
+            .with(@workflow_id, { state: StateMachine::FAILED.to_s, finished_at: @frozen_time }, { expected_old_state: StateMachine::RUNNING })
+            .returns(true)
+          repo.expects(:find_workflow).with(@workflow_id).returns(final_wf_record) # For event payload
+          notifier.expects(:publish).with('yantra.workflow.failed', has_entries(workflow_id: @workflow_id, state: :failed))
 
+          # Act
           orchestrator.step_finished(@step_a_id)
+          # Assertions handled by mock verification
         end
       end
-      # =========================================================================
 
 
-      # --- Test step_finished (Failure Path) ---
+      # --- Test step failure/cancellation propagation ---
 
-      # =========================================================================
-      # MOCHA TEST - Using Sequence
-      # =========================================================================
+      # --- UPDATED: Test step_finished with failed state ---
+      # test/core/orchestrator_test.rb (Specific Test - Fixed)
+
       def test_step_finished_failure_cancels_dependents_recursively
         mocks = setup_mocha_mocks_and_orchestrator
         repo = mocks[:repo]; notifier = mocks[:notifier]; orchestrator = mocks[:orchestrator]
-        sequence = Mocha::Sequence.new('step_finished_failure_cancels')
+        # Setup: A failed, B depends on A (pending), C depends on B (pending)
+        step_a_failed = MockStep.new(id: @step_a_id, workflow_id: @workflow_id, state: 'failed')
+        step_b_pending = MockStep.new(id: @step_b_id, workflow_id: @workflow_id, klass: "StepB", state: 'pending')
+        step_c_pending = MockStep.new(id: @step_c_id, workflow_id: @workflow_id, klass: "StepC", state: 'pending')
+        step_b_cancelled = MockStep.new(id: @step_b_id, workflow_id: @workflow_id, klass: "StepB", state: 'cancelled')
+        step_c_cancelled = MockStep.new(id: @step_c_id, workflow_id: @workflow_id, klass: "StepC", state: 'cancelled')
+        workflow_running = MockWorkflow.new(id: @workflow_id, klass: "MyWorkflow", state: 'running')
+        workflow_failed = MockWorkflow.new(id: @workflow_id, klass: "MyWorkflow", state: 'failed', finished_at: @frozen_time)
 
         Time.stub :current, @frozen_time do
-          step_a = MockStep.new(id: @step_a_id, workflow_id: @workflow_id, klass: "StepA", state: 'failed')
-          step_b = MockStep.new(id: @step_b_id, workflow_id: @workflow_id, klass: "StepB", state: 'pending')
-          step_c = MockStep.new(id: @step_c_id, workflow_id: @workflow_id, klass: "StepC", state: 'pending')
-          workflow_failed = MockWorkflow.new(id: @workflow_id, klass: "TestWorkflow", state: 'failed', finished_at: @frozen_time, has_failures: true)
+          # --- Re-introduce Sequence ---
+          sequence = Mocha::Sequence.new('failure_cascade')
 
-          # --- Mocha Expectations ---
-          repo.expects(:find_step).with(@step_a_id).returns(step_a).in_sequence(sequence) # In step_finished
-          repo.expects(:get_step_dependents).with(@step_a_id).returns([@step_b_id]).in_sequence(sequence) # In process_dependents
-          repo.expects(:find_step).with(@step_b_id).returns(step_b).in_sequence(sequence) # In cancel_downstream_pending (check B state)
-          repo.expects(:cancel_steps_bulk).with([@step_b_id]).returns(1).in_sequence(sequence) # In cancel_downstream_pending (cancel B)
-          notifier.expects(:publish).with('yantra.step.cancelled', has_entries(step_id: @step_b_id)).in_sequence(sequence) # In cancel_downstream_pending (publish B cancelled)
-          repo.expects(:get_step_dependents).with(@step_b_id).returns([@step_c_id]).in_sequence(sequence) # In cancel_downstream_pending (find C)
-          repo.expects(:find_step).with(@step_c_id).returns(step_c).in_sequence(sequence) # In recursive cancel_downstream_pending (check C state)
-          repo.expects(:cancel_steps_bulk).with([@step_c_id]).returns(1).in_sequence(sequence) # In recursive cancel_downstream_pending (cancel C)
-          notifier.expects(:publish).with('yantra.step.cancelled', has_entries(step_id: @step_c_id)).in_sequence(sequence) # In recursive cancel_downstream_pending (publish C cancelled)
-          repo.expects(:get_step_dependents).with(@step_c_id).returns([]).in_sequence(sequence) # In recursive cancel_downstream_pending (find C dependents)
-          # Workflow Completion Checks:
+          # Expectations for step_finished(A)
+          repo.expects(:find_step).with(@step_a_id).returns(step_a_failed).in_sequence(sequence)
+          repo.expects(:get_step_dependents).with(@step_a_id).returns([@step_b_id]).in_sequence(sequence) # B depends on A
+
+          # Expectations for process_dependents (Optimized Failure Path)
+          repo.expects(:get_step_dependencies_multi).with([@step_b_id]).returns({ @step_b_id => [@step_a_id] }).in_sequence(sequence)
+          repo.expects(:fetch_step_states).with([@step_a_id]).returns({@step_a_id => 'failed'}).in_sequence(sequence)
+
+          # Expectations for cancel_downstream_pending(B)
+          repo.expects(:find_step).with(@step_b_id).returns(step_b_pending).in_sequence(sequence) # Inside cancel(B)
+          repo.expects(:update_step_attributes)
+            .with(@step_b_id, { state: StateMachine::CANCELLED.to_s, finished_at: @frozen_time }, expected_old_state: StateMachine::PENDING)
+            .returns(true).in_sequence(sequence)
+          repo.expects(:find_step).with(@step_b_id).returns(step_b_cancelled).in_sequence(sequence) # Inside cancel(B) for event
+          notifier.expects(:publish).with('yantra.step.cancelled', has_entries(step_id: @step_b_id)).in_sequence(sequence)
+          repo.expects(:get_step_dependents).with(@step_b_id).returns([@step_c_id]).in_sequence(sequence) # Inside cancel(B), find C
+
+          # Expectations for recursive call cancel_downstream_pending(C)
+          repo.expects(:find_step).with(@step_c_id).returns(step_c_pending).in_sequence(sequence) # Inside cancel(C)
+          repo.expects(:update_step_attributes)
+            .with(@step_c_id, { state: StateMachine::CANCELLED.to_s, finished_at: @frozen_time }, expected_old_state: StateMachine::PENDING)
+            .returns(true).in_sequence(sequence)
+          repo.expects(:find_step).with(@step_c_id).returns(step_c_cancelled).in_sequence(sequence) # Inside cancel(C) for event
+          notifier.expects(:publish).with('yantra.step.cancelled', has_entries(step_id: @step_c_id)).in_sequence(sequence)
+          repo.expects(:get_step_dependents).with(@step_c_id).returns([]).in_sequence(sequence) # Inside cancel(C), find no dependents
+
+          # Expectations for check_workflow_completion (called after A finishes)
           repo.expects(:running_step_count).with(@workflow_id).returns(0).in_sequence(sequence)
           repo.expects(:enqueued_step_count).with(@workflow_id).returns(0).in_sequence(sequence)
-          # --- Corrected Sequence for check_workflow_completion ---
-          repo.expects(:workflow_has_failures?).with(@workflow_id).returns(true).in_sequence(sequence)
-          repo.expects(:update_workflow_attributes).with(
-            @workflow_id,
-            has_entries(state: StateMachine::FAILED.to_s, finished_at: @frozen_time),
-            { expected_old_state: StateMachine::RUNNING }
-          ).returns(true).in_sequence(sequence)
-          repo.expects(:find_workflow).with(@workflow_id).returns(workflow_failed).in_sequence(sequence)
-          # ---------------------------------------------
-          notifier.expects(:publish).with(
-            'yantra.workflow.failed',
-            has_entries(workflow_id: @workflow_id, state: StateMachine::FAILED) # Use constant symbol
-          ).returns(nil).in_sequence(sequence)
-          # --- End Mocha Expectations ---
+          repo.expects(:find_workflow).with(@workflow_id).returns(workflow_running).in_sequence(sequence) # Check if terminal
+          repo.expects(:workflow_has_failures?).with(@workflow_id).returns(true).in_sequence(sequence) # Assume flag was set
+          repo.expects(:update_workflow_attributes) # Update to failed
+            .with(@workflow_id, has_entries(state: StateMachine::FAILED.to_s), expected_old_state: StateMachine::RUNNING)
+            .returns(true).in_sequence(sequence)
+          repo.expects(:find_workflow).with(@workflow_id).returns(workflow_failed).in_sequence(sequence) # For event payload
+          notifier.expects(:publish).with('yantra.workflow.failed', has_entries(workflow_id: @workflow_id, state: :failed)).in_sequence(sequence)
 
+          # Act
           orchestrator.step_finished(@step_a_id)
+          # Assertions handled by mock verification
         end
       end
+
+
+
+
       # =========================================================================
 
 
@@ -548,68 +485,88 @@ end
 
       # (Converted to Mocha - Corrected v20: Removed eventing expectations)
 
-      def test_enqueue_step_handles_worker_error_and_reverts_state
+      def test_enqueue_step_handles_worker_error_and_reverts_state # Or ...and_marks_step_failed
         mocks = setup_mocha_mocks_and_orchestrator
         repo = mocks[:repo]; worker = mocks[:worker]; notifier = mocks[:notifier]; orchestrator = mocks[:orchestrator]
-        sequence = Mocha::Sequence.new('enqueue_step_handles_worker_error') # Use sequence again
+        sequence = Mocha::Sequence.new('enqueue_step_handles_worker_error')
 
         Time.stub :current, @frozen_time do
-          initial_job = MockStep.new(id: @step_a_id, workflow_id: @workflow_id, klass: "StepA", state: 'pending') # Data only
-          # Mock workflow record needed for the publish call in start_workflow
+          initial_job = MockStep.new(id: @step_a_id, workflow_id: @workflow_id, klass: "StepA", state: 'pending', queue: 'q_a') # Added queue
+          step_enqueued = MockStep.new(id: @step_a_id, workflow_id: @workflow_id, klass: "StepA", state: 'enqueued', queue: 'q_a', enqueued_at: @frozen_time) # Added queue
           workflow_running = MockWorkflow.new(id: @workflow_id, klass: "TestWorkflow", state: 'running', started_at: @frozen_time)
+          workflow_failed = MockWorkflow.new(id: @workflow_id, klass: "TestWorkflow", state: 'failed', finished_at: @frozen_time)
+          enqueue_error = Yantra::Errors::WorkerError.new("Queue unavailable")
 
           # --- Mocha Expectations (Corrected Sequence) ---
           # 1. Expect workflow state update to running
-          repo.expects(:update_workflow_attributes).with(
-            @workflow_id,
-            has_entries(state: StateMachine::RUNNING.to_s, started_at: @frozen_time),
-            { expected_old_state: StateMachine::PENDING }
-          ).returns(true).in_sequence(sequence)
+          repo.expects(:update_workflow_attributes)
+            .with(@workflow_id, { state: StateMachine::RUNNING.to_s, started_at: @frozen_time }, expected_old_state: StateMachine::PENDING)
+            .returns(true).in_sequence(sequence)
 
           # 2. Expect find_workflow for the 'workflow started' event payload
           repo.expects(:find_workflow).with(@workflow_id).returns(workflow_running).in_sequence(sequence)
 
-          # 3. Expect the 'workflow started' publish call
-          notifier.expects(:publish).with(
-            'yantra.workflow.started',
-            has_entries(workflow_id: @workflow_id, state: StateMachine::RUNNING)
-          ).returns(nil).in_sequence(sequence)
+          # 3. Expect the 'workflow started' publish call (Corrected Payload Check)
+          notifier.expects(:publish)
+            .with('yantra.workflow.started', has_entries(workflow_id: @workflow_id, klass: "TestWorkflow", started_at: @frozen_time)) # Check klass/started_at
+            .returns(nil).in_sequence(sequence)
 
           # 4. Expect find_ready_steps
           repo.expects(:find_ready_steps).with(@workflow_id).returns([@step_a_id]).in_sequence(sequence)
 
-          # 5. Expect find_step (for enqueue_step)
+          # --- Expectations for internal call to enqueue_step ---
+          # 5. Expect find_step (at start of enqueue_step)
           repo.expects(:find_step).with(@step_a_id).returns(initial_job).in_sequence(sequence)
 
           # 6. Expect update_step_attributes (to enqueued)
-          repo.expects(:update_step_attributes).with(
-            @step_a_id,
-            has_entries(state: StateMachine::ENQUEUED.to_s, enqueued_at: @frozen_time),
-            { expected_old_state: StateMachine::PENDING }
-          ).returns(true).in_sequence(sequence)
+          repo.expects(:update_step_attributes)
+            .with(@step_a_id, has_entries(state: StateMachine::ENQUEUED.to_s), expected_old_state: StateMachine::PENDING)
+            .returns(true).in_sequence(sequence)
 
-          # 7. Expect worker enqueue to raise the error
-          worker.expects(:enqueue)
-            .with(@step_a_id, @workflow_id, "StepA", "default")
-            .raises(Yantra::Errors::WorkerError, "Queue unavailable").in_sequence(sequence)
+          # 7. Expect find_step (for event payload / worker call)
+          repo.expects(:find_step).with(@step_a_id).returns(step_enqueued).in_sequence(sequence) # Expecting the enqueued version now
 
-          # 8. Expect the recovery actions in the rescue block of enqueue_step
-          repo.expects(:update_step_attributes).with(
-            @step_a_id,
-            has_entries(state: StateMachine::PENDING.to_s, enqueued_at: nil) # Reverted state
-          ).returns(true).in_sequence(sequence)
+          # 8. Expect publish step enqueued event
+          notifier.expects(:publish).with('yantra.step.enqueued', has_entries(step_id: @step_a_id)).in_sequence(sequence)
+
+          # 9. Expect worker enqueue to raise the error
+          worker.expects(:enqueue).with(@step_a_id, @workflow_id, "StepA", "q_a").raises(enqueue_error).in_sequence(sequence) # Use queue from mock
+
+          # --- Expectations for recovery actions in the rescue block of enqueue_step ---
+          # 10. Expect update step to FAILED (Corrected State)
+          repo.expects(:update_step_attributes)
+            .with(@step_a_id, has_entries(state: StateMachine::FAILED.to_s, error: has_key(:message))) # Expect FAILED state
+            .returns(true).in_sequence(sequence)
+          # 11. Expect set workflow failure flag
           repo.expects(:set_workflow_has_failures_flag).with(@workflow_id).returns(true).in_sequence(sequence)
-          # --- End Mocha Expectations ---
+
+          # --- Expectations for check_workflow_completion ---
+          # 12. Check counts
+          repo.expects(:running_step_count).with(@workflow_id).returns(0).in_sequence(sequence)
+          repo.expects(:enqueued_step_count).with(@workflow_id).returns(0).in_sequence(sequence)
+          # 13. Check current workflow state
+          repo.expects(:find_workflow).with(@workflow_id).returns(workflow_running).in_sequence(sequence)
+          # 14. Check failures flag
+          repo.expects(:workflow_has_failures?).with(@workflow_id).returns(true).in_sequence(sequence)
+          # 15. Update workflow to failed
+          repo.expects(:update_workflow_attributes)
+            .with(@workflow_id, has_entries(state: StateMachine::FAILED.to_s), expected_old_state: StateMachine::RUNNING)
+            .returns(true).in_sequence(sequence)
+          # 16. Find workflow for event payload
+          repo.expects(:find_workflow).with(@workflow_id).returns(workflow_failed).in_sequence(sequence)
+          # 17. Publish workflow failed event
+          notifier.expects(:publish).with('yantra.workflow.failed', has_entries(workflow_id: @workflow_id, state: :failed)).in_sequence(sequence)
+          # --- End Expectations ---
 
           # Act
-          # This calls start_workflow, which should trigger the sequence above
+          # This test calls start_workflow, which should trigger the sequence above
           orchestrator.start_workflow(@workflow_id)
 
           # Assert: Verification of expects happens automatically via Mocha teardown
         end
       end
 
-        # --- Test step_starting ---
+      # --- Test step_starting ---
       def test_step_starting_publishes_event_on_success
         mocks = setup_mocha_mocks_and_orchestrator
         repo = mocks[:repo]; notifier = mocks[:notifier]; orchestrator = mocks[:orchestrator]

--- a/test/dummy/config/database.yml
+++ b/test/dummy/config/database.yml
@@ -1,25 +1,44 @@
 # test/dummy/config/database.yml
-# SQLite. Versions 3.8.0 and up are supported.
-# Configure using environmental variables or specify default values.
+
+# Default settings applied to all environments
 default: &default
-  adapter: sqlite3
+  adapter: postgresql
+  encoding: unicode
+  # For details on connection pooling, see Rails configuration guide
+  # https://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  timeout: 5000
 
 development:
   <<: *default
-  database: db/development.sqlite3
+  database: yantra_development # Or your preferred dev DB name
+  # Optional: Add username, password, host, port if needed for dev
+  # username: postgres
+  # password: <%= ENV['YANTRA_DATABASE_PASSWORD'] %>
+  # host: localhost
+  # port: 5432
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: db/test.sqlite3
-  # Use in-memory for faster tests if preferred, but file-based is needed for schema dump
-  # database: ":memory:"
+  # Use a specific test database name
+  database: yantra_test
 
-production:
-  <<: *default
-  database: db/production.sqlite3
+  # Use environment variables for flexibility (especially in CI)
+  # Provide defaults suitable for common local PostgreSQL setups
+  username: <%= ENV.fetch('PG_USER') { 'postgres' } %>
+  password: <%= ENV.fetch('PG_PASSWORD') { nil } %> # Often blank for local trust auth
+  host: <%= ENV.fetch('PG_HOST') { 'localhost' } %>
+  port: <%= ENV.fetch('PG_PORT') { 5432 } %>
+
+# Example Production Configuration (using ENV variables)
+# production:
+#   <<: *default
+#   database: yantra_production
+#   username: yantra_user
+#   password: <%= ENV['YANTRA_DATABASE_PASSWORD'] %>
+#   host: <%= ENV['YANTRA_DATABASE_HOST'] %>
+#   port: <%= ENV['YANTRA_DATABASE_PORT'] %>
+
 

--- a/test/dummy/config/storage.yml
+++ b/test/dummy/config/storage.yml
@@ -1,0 +1,15 @@
+test:
+  service: Disk
+  root: <%= Rails.root.join("tmp/storage") %>
+
+local:
+  service: Disk
+  root: <%= Rails.root.join("storage") %>
+
+# Example for Amazon S3 (if needed for other environments)
+# amazon:
+#   service: S3
+#   access_key_id: <%= Rails.application.credentials.dig(:aws, :access_key_id) %>
+#   secret_access_key: <%= Rails.application.credentials.dig(:aws, :secret_access_key) %>
+#   region: us-east-1
+#   bucket: your_bucket_name

--- a/test/integration/integration_test.rb
+++ b/test/integration/integration_test.rb
@@ -267,7 +267,7 @@ module Yantra
          step_f_record.reload
          assert_equal "failed", step_f_record.state
          refute_nil step_f_record.error
-         error = JSON.parse(step_f_record.error)
+         error = step_f_record.error
          assert_equal "StandardError", error['class'] # Access deserialized hash with symbol
          step_a_record.reload
          assert_equal "cancelled", step_a_record.state
@@ -406,7 +406,7 @@ module Yantra
          assert_equal "running", step_r_record.state # State remains running during retry cycle
          assert_equal 1, step_r_record.retries
          refute_nil step_r_record.error
-         error = JSON.parse(step_r_record.error)
+         error = step_r_record.error
          assert_equal "StandardError", error['class']
          # Check that job is still enqueued for the next attempt
 

--- a/test/support/db/schema.rb
+++ b/test/support/db/schema.rb
@@ -10,46 +10,52 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_04_16_121554) do
+ActiveRecord::Schema[7.2].define(version: 2025_04_17_192035) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
   create_table "yantra_step_dependencies", id: false, force: :cascade do |t|
     t.string "step_id", limit: 36, null: false
     t.string "depends_on_step_id", limit: 36, null: false
-    t.index ["depends_on_step_id"], name: "idx_step_dependencies_on_prereq"
-    t.index ["step_id", "depends_on_step_id"], name: "idx_step_dependencies_unique", unique: true
+    t.index ["depends_on_step_id"], name: "index_yantra_step_dependencies_on_depends_on_step_id"
+    t.index ["step_id", "depends_on_step_id"], name: "index_yantra_step_dependencies_on_step_and_depends_on", unique: true
   end
 
   create_table "yantra_steps", id: { type: :string, limit: 36 }, force: :cascade do |t|
     t.string "workflow_id", limit: 36, null: false
     t.string "klass", null: false
-    t.json "arguments"
+    t.jsonb "arguments"
     t.string "state", null: false
     t.string "queue"
     t.integer "retries", default: 0, null: false
-    t.json "output"
-    t.json "error"
-    t.boolean "is_terminal", default: false, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.datetime "enqueued_at"
-    t.datetime "started_at"
-    t.datetime "finished_at"
+    t.integer "max_attempts", default: 3, null: false
+    t.jsonb "output"
+    t.jsonb "error"
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "enqueued_at", precision: nil
+    t.datetime "started_at", precision: nil
+    t.datetime "finished_at", precision: nil
     t.index ["state"], name: "index_yantra_steps_on_state"
-    t.index ["workflow_id", "state"], name: "index_yantra_steps_on_workflow_id_and_state"
     t.index ["workflow_id"], name: "index_yantra_steps_on_workflow_id"
   end
 
   create_table "yantra_workflows", id: { type: :string, limit: 36 }, force: :cascade do |t|
     t.string "klass", null: false
-    t.json "arguments"
+    t.jsonb "arguments"
     t.string "state", null: false
-    t.json "globals"
+    t.jsonb "globals"
     t.boolean "has_failures", default: false, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.datetime "started_at"
-    t.datetime "finished_at"
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "started_at", precision: nil
+    t.datetime "finished_at", precision: nil
     t.index ["finished_at"], name: "index_yantra_workflows_on_finished_at"
     t.index ["started_at"], name: "index_yantra_workflows_on_started_at"
     t.index ["state"], name: "index_yantra_workflows_on_state"
   end
+
+  add_foreign_key "yantra_step_dependencies", "yantra_steps", column: "depends_on_step_id", on_delete: :cascade
+  add_foreign_key "yantra_step_dependencies", "yantra_steps", column: "step_id", on_delete: :cascade
+  add_foreign_key "yantra_steps", "yantra_workflows", column: "workflow_id", on_delete: :cascade
 end

--- a/yantra.gemspec
+++ b/yantra.gemspec
@@ -55,6 +55,7 @@ Yantra aims to be a robust, developer-friendly solution for managing background 
   spec.add_development_dependency "database_cleaner-active_record"
   spec.add_development_dependency "mocha"
   spec.add_development_dependency "pry"
+  spec.add_development_dependency "pg"
 
   # spec.add_development_dependency "database_cleaner-active_record" # If using DatabaseCleaner
 end


### PR DESCRIPTION
Logic that determines if dependents can start within the Orchestrator previously used N+1 queries through the Repo. This uses simple Repository accessors but uses smart access patterns to avoid those N+1 queries.